### PR TITLE
[css3-text] using full-width instead of fullwidth due to current spec

### DIFF
--- a/approved/css3-text/src/text-transform-fullwidth-001.xht
+++ b/approved/css3-text/src/text-transform-fullwidth-001.xht
@@ -12,7 +12,7 @@
 		<style type="text/css">
 			<![CDATA[
 				.test span {
-					text-transform: fullwidth;
+					text-transform: full-width;
 				}
 				/* the CSS below is not part of the test */
 				span {


### PR DESCRIPTION
Current editor draft (http://dev.w3.org/csswg/css-text/) and working draft (http://www.w3.org/TR/css3-text/) use full-width value for text-transform property.   But this text uses fullwidth value.  It seems to be typo.
