### PR TITLE
New tests for css3 counter styles

### DIFF
--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-001.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-001.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>cjk-decimal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: cjk-decimal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class='test'><ol>
+				<li title='1'>一、</li>
+				<li title='2'>二、</li>
+				<li title='3'>三、</li>
+
+				<li title='4'>四、</li>
+				<li title='5'>五、</li>
+				<li title='6'>六、</li>
+				<li title='7'>七、</li>
+				<li title='8'>八、</li>
+
+				<li title='9'>九、</li>
+			</ol>
+			</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-004.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-004.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>cjk-decimal, 10+</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: cjk-decimal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class='test'><ol start='10'>
+				<li title='10'>一〇、</li>
+				<li title='11'>一一、</li>
+				<li title='12'>一二、</li>
+			</ol>
+
+			<ol start='43'>
+				<li title='43'>四三、</li>
+			</ol>
+			<ol start='77'>
+				<li title='77'>七七、</li>
+			</ol>
+			<ol start='80'>
+
+				<li title='80'>八〇、</li>
+			</ol>
+			<ol start='99'>
+				<li title='99'>九九、</li>
+				<li title='100'>一〇〇、</li>
+				<li title='101'>一〇一、</li>
+
+			</ol>
+			<ol start='222'>
+				<li title='222'>二二二、</li>
+			</ol>
+			<ol start='540'>
+				<li title='540'>五四〇、</li>
+			</ol>
+
+			<ol start='999'>
+				<li title='999'>九九九、</li>
+				<li title='1000'>一〇〇〇、</li>
+			</ol>
+			<ol start='1005'>
+				<li title='1005'>一〇〇五、</li>
+
+			</ol>
+			<ol start='1060'>
+				<li title='1060'>一〇六〇、</li>
+			</ol>
+			<ol start='1065'>
+				<li title='1065'>一〇六五、</li>
+			</ol>
+
+			<ol start='1800'>
+				<li title='1800'>一八〇〇、</li>
+			</ol>
+			<ol start='1860'>
+				<li title='1860'>一八六〇、</li>
+			</ol>
+			<ol start='1865'>
+
+				<li title='1865'>一八六五、</li>
+			</ol>
+			<ol start='5865'>
+				<li title='5865'>五八六五、</li>
+			</ol>
+			<ol start='7005'>
+				<li title='7005'>七〇〇五、</li>
+
+			</ol>
+			<ol start='7800'>
+				<li title='7800'>七八〇〇、</li>
+			</ol>
+			<ol start='7864'>
+				<li title='7864'>七八六四、</li>
+			</ol>
+
+			<ol start='9999'>
+				<li title='9999'>九九九九、</li>
+			</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-005.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-005.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>cjk-decimal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: cjk-decimal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class='test'><ol>
+				<li title='1'>一、</li>
+				<li title='2'>二、</li>
+				<li title='3'>三、</li>
+
+				<li title='4'>四、</li>
+				<li title='5'>五、</li>
+				<li title='6'>六、</li>
+				<li title='7'>七、</li>
+				<li title='8'>八、</li>
+
+				<li title='9'>九、</li>
+			</ol>
+			</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-006.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-006.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>armenian, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: armenian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>Ա.</li></ol>
+<ol start='2'><li title='2'>Բ.</li></ol>
+<ol start='3'><li title='3'>Գ.</li></ol>
+<ol start='4'><li title='4'>Դ.</li></ol>
+<ol start='5'><li title='5'>Ե.</li></ol>
+<ol start='6'><li title='6'>Զ.</li></ol>
+<ol start='7'><li title='7'>Է.</li></ol>
+<ol start='8'><li title='8'>Ը.</li></ol>
+<ol start='9'><li title='9'>Թ.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-007.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-007.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>armenian, 10+</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: armenian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>Ժ.</li></ol>
+<ol start='11'><li title='11'>ԺԱ.</li></ol>
+<ol start='12'><li title='12'>ԺԲ.</li></ol>
+<ol start='43'><li title='43'>ԽԳ.</li></ol>
+<ol start='77'><li title='77'>ՀԷ.</li></ol>
+<ol start='80'><li title='80'>Ձ.</li></ol>
+<ol start='99'><li title='99'>ՂԹ.</li></ol>
+<ol start='100'><li title='100'>Ճ.</li></ol>
+<ol start='101'><li title='101'>ՃԱ.</li></ol>
+<ol start='222'><li title='222'>ՄԻԲ.</li></ol>
+<ol start='540'><li title='540'>ՇԽ.</li></ol>
+<ol start='999'><li title='999'>ՋՂԹ.</li></ol>
+<ol start='1000'><li title='1000'>Ռ.</li></ol>
+<ol start='1005'><li title='1005'>ՌԵ.</li></ol>
+<ol start='1060'><li title='1060'>ՌԿ.</li></ol>
+<ol start='1065'><li title='1065'>ՌԿԵ.</li></ol>
+<ol start='1800'><li title='1800'>ՌՊ.</li></ol>
+<ol start='1860'><li title='1860'>ՌՊԿ.</li></ol>
+<ol start='1865'><li title='1865'>ՌՊԿԵ.</li></ol>
+<ol start='5865'><li title='5865'>ՐՊԿԵ.</li></ol>
+<ol start='7005'><li title='7005'>ՒԵ.</li></ol>
+<ol start='7800'><li title='7800'>ՒՊ.</li></ol>
+<ol start='7865'><li title='7865'>ՒՊԿԵ.</li></ol>
+<ol start='9999'><li title='9999'>ՔՋՂԹ.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-008.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-008.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>armenian, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: armenian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10000'><li title='10000'>10000.</li></ol>
+<ol start='10001'><li title='10001'>10001.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-009.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-009.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>armenian, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: armenian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>Ա.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-010.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-010.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>georgian, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: georgian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>ა.</li></ol>
+<ol start='2'><li title='2'>ბ.</li></ol>
+<ol start='3'><li title='3'>გ.</li></ol>
+<ol start='4'><li title='4'>დ.</li></ol>
+<ol start='5'><li title='5'>ე.</li></ol>
+<ol start='6'><li title='6'>ვ.</li></ol>
+<ol start='7'><li title='7'>ზ.</li></ol>
+<ol start='8'><li title='8'>ჱ.</li></ol>
+<ol start='9'><li title='9'>თ.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-011.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-011.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>georgian, 10+</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: georgian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>ი.</li></ol>
+<ol start='11'><li title='11'>ია.</li></ol>
+<ol start='12'><li title='12'>იბ.</li></ol>
+<ol start='43'><li title='43'>მგ.</li></ol>
+<ol start='77'><li title='77'>ოზ.</li></ol>
+<ol start='80'><li title='80'>პ.</li></ol>
+<ol start='99'><li title='99'>ჟთ.</li></ol>
+<ol start='100'><li title='100'>რ.</li></ol>
+<ol start='101'><li title='101'>რა.</li></ol>
+<ol start='222'><li title='222'>სკბ.</li></ol>
+<ol start='540'><li title='540'>ფმ.</li></ol>
+<ol start='999'><li title='999'>შჟთ.</li></ol>
+<ol start='1000'><li title='1000'>ჩ.</li></ol>
+<ol start='1005'><li title='1005'>ჩე.</li></ol>
+<ol start='1060'><li title='1060'>ჩჲ.</li></ol>
+<ol start='1065'><li title='1065'>ჩჲე.</li></ol>
+<ol start='1800'><li title='1800'>ჩყ.</li></ol>
+<ol start='1860'><li title='1860'>ჩყჲ.</li></ol>
+<ol start='1865'><li title='1865'>ჩყჲე.</li></ol>
+<ol start='5865'><li title='5865'>ჭყჲე.</li></ol>
+<ol start='7005'><li title='7005'>ჴე.</li></ol>
+<ol start='7800'><li title='7800'>ჴყ.</li></ol>
+<ol start='7865'><li title='7865'>ჴყჲე.</li></ol>
+<ol start='9999'><li title='9999'>ჰშჟთ.</li></ol>
+<ol start='10000'><li title='10000'>ჵ.</li></ol>
+<ol start='10001'><li title='10001'>ჵა.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-012.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-012.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>georgian, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: georgian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='20000'><li title='20000'>20000.</li></ol>
+<ol start='20001'><li title='20001'>20001.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-014.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-014.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>georgian, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: georgian;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>ა.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-015.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-015.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hebrew, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hebrew;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>א.</li></ol>
+<ol start='2'><li title='2'>ב.</li></ol>
+<ol start='3'><li title='3'>ג.</li></ol>
+<ol start='4'><li title='4'>ד.</li></ol>
+<ol start='5'><li title='5'>ה.</li></ol>
+<ol start='6'><li title='6'>ו.</li></ol>
+<ol start='7'><li title='7'>ז.</li></ol>
+<ol start='8'><li title='8'>ח.</li></ol>
+<ol start='9'><li title='9'>ט.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-016.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-016.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hebrew, 10+</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hebrew;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>י.</li></ol>
+<ol start='11'><li title='11'>יא.</li></ol>
+<ol start='12'><li title='12'>יב.</li></ol>
+<ol start='13'><li title='13'>יג.</li></ol>
+<ol start='14'><li title='14'>יד.</li></ol>
+<ol start='15'><li title='15'>טו.</li></ol>
+<ol start='16'><li title='16'>טז.</li></ol>
+<ol start='17'><li title='17'>יז.</li></ol>
+<ol start='18'><li title='18'>יח.</li></ol>
+<ol start='43'><li title='43'>מג.</li></ol>
+<ol start='77'><li title='77'>עז.</li></ol>
+<ol start='80'><li title='80'>פ.</li></ol>
+<ol start='99'><li title='99'>צט.</li></ol>
+<ol start='100'><li title='100'>ק.</li></ol>
+<ol start='101'><li title='101'>קא.</li></ol>
+<ol start='222'><li title='222'>רכב.</li></ol>
+<ol start='400'><li title='400'>ת.</li></ol>
+<ol start='401'><li title='401'>תא.</li></ol>
+<ol start='499'><li title='499'>תצט.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-017.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-017.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hebrew, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hebrew;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>א.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-019.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-019.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-roman, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>i.</li></ol>
+<ol start='2'><li title='2'>ii.</li></ol>
+<ol start='3'><li title='3'>iii.</li></ol>
+<ol start='4'><li title='4'>iv.</li></ol>
+<ol start='5'><li title='5'>v.</li></ol>
+<ol start='6'><li title='6'>vi.</li></ol>
+<ol start='7'><li title='7'>vii.</li></ol>
+<ol start='8'><li title='8'>viii.</li></ol>
+<ol start='9'><li title='9'>ix.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-020.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-020.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-roman, 10-3999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>x.</li></ol>
+<ol start='11'><li title='11'>xi.</li></ol>
+<ol start='12'><li title='12'>xii.</li></ol>
+<ol start='43'><li title='43'>xliii.</li></ol>
+<ol start='77'><li title='77'>lxxvii.</li></ol>
+<ol start='80'><li title='80'>lxxx.</li></ol>
+<ol start='99'><li title='99'>xcix.</li></ol>
+<ol start='100'><li title='100'>c.</li></ol>
+<ol start='101'><li title='101'>ci.</li></ol>
+<ol start='222'><li title='222'>ccxxii.</li></ol>
+<ol start='540'><li title='540'>dxl.</li></ol>
+<ol start='999'><li title='999'>cmxcix.</li></ol>
+<ol start='1000'><li title='1000'>m.</li></ol>
+<ol start='1005'><li title='1005'>mv.</li></ol>
+<ol start='1060'><li title='1060'>mlx.</li></ol>
+<ol start='1065'><li title='1065'>mlxv.</li></ol>
+<ol start='1800'><li title='1800'>mdccc.</li></ol>
+<ol start='1860'><li title='1860'>mdccclx.</li></ol>
+<ol start='1865'><li title='1865'>mdccclxv.</li></ol>
+<ol start='2555'><li title='2555'>mmdlv.</li></ol>
+<ol start='3000'><li title='3000'>mmm.</li></ol>
+<ol start='3999'><li title='3999'>mmmcmxcix.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-020a.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-020a.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-roman, 4000-4999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='4000'><li title='4000'>mmmm.</li></ol>
+<ol start='4555'><li title='4555'>mmmmdlv.</li></ol>
+<ol start='4998'><li title='4998'>mmmmcmxcviii.</li></ol>
+<ol start='4999'><li title='4999'>mmmmcmxcix.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-021.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-021.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-roman, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='5000'><li title='5000'>5000.</li></ol>
+<ol start='5001'><li title='5001'>5001.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-022.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-022.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-roman, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>i.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-023.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-023.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>upper-roman, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: upper-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>I.</li></ol>
+<ol start='2'><li title='2'>II.</li></ol>
+<ol start='3'><li title='3'>III.</li></ol>
+<ol start='4'><li title='4'>IV.</li></ol>
+<ol start='5'><li title='5'>V.</li></ol>
+<ol start='6'><li title='6'>VI.</li></ol>
+<ol start='7'><li title='7'>VII.</li></ol>
+<ol start='8'><li title='8'>VIII.</li></ol>
+<ol start='9'><li title='9'>IX.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-024.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-024.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>upper-roman, 10-3999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: upper-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>X.</li></ol>
+<ol start='11'><li title='11'>XI.</li></ol>
+<ol start='12'><li title='12'>XII.</li></ol>
+<ol start='43'><li title='43'>XLIII.</li></ol>
+<ol start='77'><li title='77'>LXXVII.</li></ol>
+<ol start='80'><li title='80'>LXXX.</li></ol>
+<ol start='99'><li title='99'>XCIX.</li></ol>
+<ol start='100'><li title='100'>C.</li></ol>
+<ol start='101'><li title='101'>CI.</li></ol>
+<ol start='222'><li title='222'>CCXXII.</li></ol>
+<ol start='540'><li title='540'>DXL.</li></ol>
+<ol start='999'><li title='999'>CMXCIX.</li></ol>
+<ol start='1000'><li title='1000'>M.</li></ol>
+<ol start='1005'><li title='1005'>MV.</li></ol>
+<ol start='1060'><li title='1060'>MLX.</li></ol>
+<ol start='1065'><li title='1065'>MLXV.</li></ol>
+<ol start='1800'><li title='1800'>MDCCC.</li></ol>
+<ol start='1860'><li title='1860'>MDCCCLX.</li></ol>
+<ol start='1865'><li title='1865'>MDCCCLXV.</li></ol>
+<ol start='2555'><li title='2555'>MMDLV.</li></ol>
+<ol start='3000'><li title='3000'>MMM.</li></ol>
+<ol start='3999'><li title='3999'>MMMCMXCIX.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-024a.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-024a.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>upper-roman, 4000-4999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: upper-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='4000'><li title='4000'>MMMM.</li></ol>
+<ol start='4555'><li title='4555'>MMMMDLV.</li></ol>
+<ol start='4998'><li title='4998'>MMMMCMXCVIII.</li></ol>
+<ol start='4999'><li title='4999'>MMMMCMXCIX.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-025.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-025.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>upper-roman, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: upper-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='5000'><li title='5000'>5000.</li></ol>
+<ol start='5001'><li title='5001'>5001.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-026.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-026.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>upper-roman, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: upper-roman;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>I.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-027.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-027.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-greek, simple</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-greek;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol><li title='1'>α.</li>
+<li title='2'>β.</li>
+<li title='3'>γ.</li>
+<li title='4'>δ.</li>
+<li title='5'>ε.</li>
+<li title='6'>ζ.</li>
+<li title='7'>η.</li>
+<li title='8'>θ.</li>
+<li title='9'>ι.</li>
+<li title='10'>κ.</li>
+<li title='11'>λ.</li>
+<li title='12'>μ.</li>
+<li title='13'>ν.</li>
+<li title='14'>ξ.</li>
+<li title='15'>ο.</li>
+<li title='16'>π.</li>
+<li title='17'>ρ.</li>
+<li title='18'>σ.</li>
+<li title='19'>τ.</li>
+<li title='20'>υ.</li>
+<li title='21'>φ.</li>
+<li title='22'>χ.</li>
+<li title='23'>ψ.</li>
+<li title='24'>ω.</li>
+</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-028.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-028.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-greek, extended</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-greek;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='25'><li title='25'>αα.</li></ol>
+<ol start='26'><li title='26'>αβ.</li></ol>
+<ol start='43'><li title='43'>ατ.</li></ol>
+<ol start='77'><li title='77'>γε.</li></ol>
+<ol start='80'><li title='80'>γθ.</li></ol>
+<ol start='99'><li title='99'>δγ.</li></ol>
+<ol start='100'><li title='100'>δδ.</li></ol>
+<ol start='101'><li title='101'>δε.</li></ol>
+<ol start='222'><li title='222'>ιζ.</li></ol>
+<ol start='540'><li title='540'>χμ.</li></ol>
+<ol start='999'><li title='999'>αρο.</li></ol>
+<ol start='1000'><li title='1000'>αρπ.</li></ol>
+<ol start='1005'><li title='1005'>αρφ.</li></ol>
+<ol start='1060'><li title='1060'>αυδ.</li></ol>
+<ol start='1065'><li title='1065'>αυι.</li></ol>
+<ol start='1800'><li title='1800'>γβω.</li></ol>
+<ol start='1860'><li title='1860'>γεμ.</li></ol>
+<ol start='5865'><li title='5865'>κδι.</li></ol>
+<ol start='7005'><li title='7005'>μγφ.</li></ol>
+<ol start='7800'><li title='7800'>νμω.</li></ol>
+<ol start='7864'><li title='7864'>νοπ.</li></ol>
+<ol start='9999'><li title='9999'>ρθο.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-029.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-029.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>lower-greek, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: lower-greek;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>α.</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-030.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-030.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana, simple</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol><li title='1'>あ、</li>
+<li title='2'>い、</li>
+<li title='3'>う、</li>
+<li title='4'>え、</li>
+<li title='5'>お、</li>
+<li title='6'>か、</li>
+<li title='7'>き、</li>
+<li title='8'>く、</li>
+<li title='9'>け、</li>
+<li title='10'>こ、</li>
+<li title='11'>さ、</li>
+<li title='12'>し、</li>
+<li title='13'>す、</li>
+<li title='14'>せ、</li>
+<li title='15'>そ、</li>
+<li title='16'>た、</li>
+<li title='17'>ち、</li>
+<li title='18'>つ、</li>
+<li title='19'>て、</li>
+<li title='20'>と、</li>
+<li title='21'>な、</li>
+<li title='22'>に、</li>
+<li title='23'>ぬ、</li>
+<li title='24'>ね、</li>
+<li title='25'>の、</li>
+<li title='26'>は、</li>
+<li title='27'>ひ、</li>
+<li title='28'>ふ、</li>
+<li title='29'>へ、</li>
+<li title='30'>ほ、</li>
+<li title='31'>ま、</li>
+<li title='32'>み、</li>
+<li title='33'>む、</li>
+<li title='34'>め、</li>
+<li title='35'>も、</li>
+<li title='36'>や、</li>
+<li title='37'>ゆ、</li>
+<li title='38'>よ、</li>
+<li title='39'>ら、</li>
+<li title='40'>り、</li>
+<li title='41'>る、</li>
+<li title='42'>れ、</li>
+<li title='43'>ろ、</li>
+<li title='44'>わ、</li>
+<li title='45'>を、</li>
+<li title='46'>ん、</li>
+</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-031.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-031.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana, extended</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='47'><li title='47'>ああ、</li></ol>
+<ol start='48'><li title='48'>あい、</li></ol>
+<ol start='49'><li title='49'>あう、</li></ol>
+<ol start='77'><li title='77'>あま、</li></ol>
+<ol start='80'><li title='80'>あめ、</li></ol>
+<ol start='99'><li title='99'>いき、</li></ol>
+<ol start='100'><li title='100'>いく、</li></ol>
+<ol start='101'><li title='101'>いけ、</li></ol>
+<ol start='222'><li title='222'>えよ、</li></ol>
+<ol start='540'><li title='540'>さめ、</li></ol>
+<ol start='999'><li title='999'>なむ、</li></ol>
+<ol start='1000'><li title='1000'>なめ、</li></ol>
+<ol start='1005'><li title='1005'>なら、</li></ol>
+<ol start='1060'><li title='1060'>ぬい、</li></ol>
+<ol start='1065'><li title='1065'>ぬき、</li></ol>
+<ol start='1800'><li title='1800'>らか、</li></ol>
+<ol start='1860'><li title='1860'>りと、</li></ol>
+<ol start='5865'><li title='5865'>いもぬ、</li></ol>
+<ol start='7005'><li title='7005'>うせす、</li></ol>
+<ol start='7800'><li title='7800'>うまは、</li></ol>
+<ol start='7864'><li title='7864'>うみわ、</li></ol>
+<ol start='9999'><li title='9999'>えむち、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-032.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-032.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>あ、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-033.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-033.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana-iroha, simple</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol><li title='1'>い、</li>
+<li title='2'>ろ、</li>
+<li title='3'>は、</li>
+<li title='4'>に、</li>
+<li title='5'>ほ、</li>
+<li title='6'>へ、</li>
+<li title='7'>と、</li>
+<li title='8'>ち、</li>
+<li title='9'>り、</li>
+<li title='10'>ぬ、</li>
+<li title='11'>る、</li>
+<li title='12'>を、</li>
+<li title='13'>わ、</li>
+<li title='14'>か、</li>
+<li title='15'>よ、</li>
+<li title='16'>た、</li>
+<li title='17'>れ、</li>
+<li title='18'>そ、</li>
+<li title='19'>つ、</li>
+<li title='20'>ね、</li>
+<li title='21'>な、</li>
+<li title='22'>ら、</li>
+<li title='23'>む、</li>
+<li title='24'>う、</li>
+<li title='25'>ゐ、</li>
+<li title='26'>の、</li>
+<li title='27'>お、</li>
+<li title='28'>く、</li>
+<li title='29'>や、</li>
+<li title='30'>ま、</li>
+<li title='31'>け、</li>
+<li title='32'>ふ、</li>
+<li title='33'>こ、</li>
+<li title='34'>え、</li>
+<li title='35'>て、</li>
+<li title='36'>あ、</li>
+<li title='37'>さ、</li>
+<li title='38'>き、</li>
+<li title='39'>ゆ、</li>
+<li title='40'>め、</li>
+<li title='41'>み、</li>
+<li title='42'>し、</li>
+<li title='43'>ゑ、</li>
+<li title='44'>ひ、</li>
+<li title='45'>も、</li>
+<li title='46'>せ、</li>
+<li title='47'>す、</li>
+<li title='48'>ん、</li>
+</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-034.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-034.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana-iroha, extended</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='49'><li title='49'>いい、</li></ol>
+<ol start='77'><li title='77'>いや、</li></ol>
+<ol start='80'><li title='80'>いふ、</li></ol>
+<ol start='99'><li title='99'>ろは、</li></ol>
+<ol start='100'><li title='100'>ろに、</li></ol>
+<ol start='101'><li title='101'>ろほ、</li></ol>
+<ol start='222'><li title='222'>にま、</li></ol>
+<ol start='540'><li title='540'>るを、</li></ol>
+<ol start='999'><li title='999'>ねゆ、</li></ol>
+<ol start='1000'><li title='1000'>ねめ、</li></ol>
+<ol start='1005'><li title='1005'>ねも、</li></ol>
+<ol start='1060'><li title='1060'>らに、</li></ol>
+<ol start='1065'><li title='1065'>らり、</li></ol>
+<ol start='1800'><li title='1800'>さう、</li></ol>
+<ol start='1860'><li title='1860'>きあ、</li></ol>
+<ol start='5865'><li title='5865'>ろのり、</li></ol>
+<ol start='7005'><li title='7005'>はいも、</li></ol>
+<ol start='7800'><li title='7800'>はそう、</li></ol>
+<ol start='7864'><li title='7864'>はつめ、</li></ol>
+<ol start='9999'><li title='9999'>にたよ、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-035.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-035.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>hiragana-iroha, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: hiragana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>い、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-036.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-036.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana, simple</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol><li title='1'>ア、</li>
+<li title='2'>イ、</li>
+<li title='3'>ウ、</li>
+<li title='4'>エ、</li>
+<li title='5'>オ、</li>
+<li title='6'>カ、</li>
+<li title='7'>キ、</li>
+<li title='8'>ク、</li>
+<li title='9'>ケ、</li>
+<li title='10'>コ、</li>
+<li title='11'>サ、</li>
+<li title='12'>シ、</li>
+<li title='13'>ス、</li>
+<li title='14'>セ、</li>
+<li title='15'>ソ、</li>
+<li title='16'>タ、</li>
+<li title='17'>チ、</li>
+<li title='18'>ツ、</li>
+<li title='19'>テ、</li>
+<li title='20'>ト、</li>
+<li title='21'>ナ、</li>
+<li title='22'>ニ、</li>
+<li title='23'>ヌ、</li>
+<li title='24'>ネ、</li>
+<li title='25'>ノ、</li>
+<li title='26'>ハ、</li>
+<li title='27'>ヒ、</li>
+<li title='28'>フ、</li>
+<li title='29'>ヘ、</li>
+<li title='30'>ホ、</li>
+<li title='31'>マ、</li>
+<li title='32'>ミ、</li>
+<li title='33'>ム、</li>
+<li title='34'>メ、</li>
+<li title='35'>モ、</li>
+<li title='36'>ヤ、</li>
+<li title='37'>ユ、</li>
+<li title='38'>ヨ、</li>
+<li title='39'>ラ、</li>
+<li title='40'>リ、</li>
+<li title='41'>ル、</li>
+<li title='42'>レ、</li>
+<li title='43'>ロ、</li>
+<li title='44'>ワ、</li>
+<li title='45'>ヲ、</li>
+<li title='46'>ン、</li>
+</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-037.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-037.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana, extended</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='47'><li title='47'>アア、</li></ol>
+<ol start='48'><li title='48'>アイ、</li></ol>
+<ol start='49'><li title='49'>アウ、</li></ol>
+<ol start='77'><li title='77'>アマ、</li></ol>
+<ol start='80'><li title='80'>アメ、</li></ol>
+<ol start='99'><li title='99'>イキ、</li></ol>
+<ol start='100'><li title='100'>イク、</li></ol>
+<ol start='101'><li title='101'>イケ、</li></ol>
+<ol start='222'><li title='222'>エヨ、</li></ol>
+<ol start='540'><li title='540'>サメ、</li></ol>
+<ol start='999'><li title='999'>ナム、</li></ol>
+<ol start='1000'><li title='1000'>ナメ、</li></ol>
+<ol start='1005'><li title='1005'>ナラ、</li></ol>
+<ol start='1060'><li title='1060'>ヌイ、</li></ol>
+<ol start='1065'><li title='1065'>ヌキ、</li></ol>
+<ol start='1800'><li title='1800'>ラカ、</li></ol>
+<ol start='1860'><li title='1860'>リト、</li></ol>
+<ol start='5865'><li title='5865'>イモヌ、</li></ol>
+<ol start='7005'><li title='7005'>ウセス、</li></ol>
+<ol start='7800'><li title='7800'>ウマハ、</li></ol>
+<ol start='7864'><li title='7864'>ウミワ、</li></ol>
+<ol start='9999'><li title='9999'>エムチ、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-038.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-038.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>ア、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-039.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-039.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana-iroha, simple</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol><li title='1'>イ、</li>
+<li title='2'>ロ、</li>
+<li title='3'>ハ、</li>
+<li title='4'>ニ、</li>
+<li title='5'>ホ、</li>
+<li title='6'>ヘ、</li>
+<li title='7'>ト、</li>
+<li title='8'>チ、</li>
+<li title='9'>リ、</li>
+<li title='10'>ヌ、</li>
+<li title='11'>ル、</li>
+<li title='12'>ヲ、</li>
+<li title='13'>ワ、</li>
+<li title='14'>カ、</li>
+<li title='15'>ヨ、</li>
+<li title='16'>タ、</li>
+<li title='17'>レ、</li>
+<li title='18'>ソ、</li>
+<li title='19'>ツ、</li>
+<li title='20'>ネ、</li>
+<li title='21'>ナ、</li>
+<li title='22'>ラ、</li>
+<li title='23'>ム、</li>
+<li title='24'>ウ、</li>
+<li title='25'>ヰ、</li>
+<li title='26'>ノ、</li>
+<li title='27'>オ、</li>
+<li title='28'>ク、</li>
+<li title='29'>ヤ、</li>
+<li title='30'>マ、</li>
+<li title='31'>ケ、</li>
+<li title='32'>フ、</li>
+<li title='33'>コ、</li>
+<li title='34'>エ、</li>
+<li title='35'>テ、</li>
+<li title='36'>ア、</li>
+<li title='37'>サ、</li>
+<li title='38'>キ、</li>
+<li title='39'>ユ、</li>
+<li title='40'>メ、</li>
+<li title='41'>ミ、</li>
+<li title='42'>シ、</li>
+<li title='43'>ヱ、</li>
+<li title='44'>ヒ、</li>
+<li title='45'>モ、</li>
+<li title='46'>セ、</li>
+<li title='47'>ス、</li>
+<li title='48'>ン、</li>
+</ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-040.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-040.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana-iroha, extended</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='49'><li title='49'>イイ、</li></ol>
+<ol start='77'><li title='77'>イヤ、</li></ol>
+<ol start='80'><li title='80'>イフ、</li></ol>
+<ol start='99'><li title='99'>ロハ、</li></ol>
+<ol start='100'><li title='100'>ロニ、</li></ol>
+<ol start='101'><li title='101'>ロホ、</li></ol>
+<ol start='222'><li title='222'>ニマ、</li></ol>
+<ol start='540'><li title='540'>ルヲ、</li></ol>
+<ol start='999'><li title='999'>ネユ、</li></ol>
+<ol start='1000'><li title='1000'>ネメ、</li></ol>
+<ol start='1005'><li title='1005'>ネモ、</li></ol>
+<ol start='1060'><li title='1060'>ラニ、</li></ol>
+<ol start='1065'><li title='1065'>ラリ、</li></ol>
+<ol start='1800'><li title='1800'>サウ、</li></ol>
+<ol start='1860'><li title='1860'>キア、</li></ol>
+<ol start='5865'><li title='5865'>ロノリ、</li></ol>
+<ol start='7005'><li title='7005'>ハイモ、</li></ol>
+<ol start='7800'><li title='7800'>ハソウ、</li></ol>
+<ol start='7864'><li title='7864'>ハツメ、</li></ol>
+<ol start='9999'><li title='9999'>ニタヨ、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-041.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-041.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>katakana-iroha, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: katakana-iroha;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>イ、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-042.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-042.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-informal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>〇、</li></ol>
+<ol start='1'><li title='1'>一、</li></ol>
+<ol start='2'><li title='2'>二、</li></ol>
+<ol start='3'><li title='3'>三、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>五、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-043.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-043.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-informal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>十、</li></ol>
+<ol start='11'><li title='11'>十一、</li></ol>
+<ol start='12'><li title='12'>十二、</li></ol>
+<ol start='43'><li title='43'>四十三、</li></ol>
+<ol start='77'><li title='77'>七十七、</li></ol>
+<ol start='80'><li title='80'>八十、</li></ol>
+<ol start='99'><li title='99'>九十九、</li></ol>
+<ol start='100'><li title='100'>百、</li></ol>
+<ol start='101'><li title='101'>百一、</li></ol>
+<ol start='222'><li title='222'>二百二十二、</li></ol>
+<ol start='540'><li title='540'>五百四十、</li></ol>
+<ol start='999'><li title='999'>九百九十九、</li></ol>
+<ol start='1000'><li title='1000'>千、</li></ol>
+<ol start='1005'><li title='1005'>千五、</li></ol>
+<ol start='1060'><li title='1060'>千六十、</li></ol>
+<ol start='1065'><li title='1065'>千六十五、</li></ol>
+<ol start='1800'><li title='1800'>千八百、</li></ol>
+<ol start='1860'><li title='1860'>千八百六十、</li></ol>
+<ol start='1865'><li title='1865'>千八百六十五、</li></ol>
+<ol start='5865'><li title='5865'>五千八百六十五、</li></ol>
+<ol start='7005'><li title='7005'>七千五、</li></ol>
+<ol start='7800'><li title='7800'>七千八百、</li></ol>
+<ol start='7865'><li title='7865'>七千八百六十五、</li></ol>
+<ol start='9999'><li title='9999'>九千九百九十九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-044.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-044.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-informal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-045.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-045.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-informal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">マイナス十一、</li><li title="-10">マイナス十、</li><li title="-9">マイナス九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-046.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-046.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-informal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>一、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-047.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-047.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-formal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>壱、</li></ol>
+<ol start='2'><li title='2'>弐、</li></ol>
+<ol start='3'><li title='3'>参、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>伍、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-048.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-048.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-formal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>壱拾、</li></ol>
+<ol start='11'><li title='11'>壱拾壱、</li></ol>
+<ol start='12'><li title='12'>壱拾弐、</li></ol>
+<ol start='43'><li title='43'>四拾参、</li></ol>
+<ol start='77'><li title='77'>七拾七、</li></ol>
+<ol start='80'><li title='80'>八拾、</li></ol>
+<ol start='99'><li title='99'>九拾九、</li></ol>
+<ol start='100'><li title='100'>壱百、</li></ol>
+<ol start='101'><li title='101'>壱百壱、</li></ol>
+<ol start='222'><li title='222'>弐百弐拾弐、</li></ol>
+<ol start='540'><li title='540'>伍百四拾、</li></ol>
+<ol start='999'><li title='999'>九百九拾九、</li></ol>
+<ol start='1000'><li title='1000'>壱阡、</li></ol>
+<ol start='1005'><li title='1005'>壱阡伍、</li></ol>
+<ol start='1060'><li title='1060'>壱阡六拾、</li></ol>
+<ol start='1065'><li title='1065'>壱阡六拾伍、</li></ol>
+<ol start='1800'><li title='1800'>壱阡八百、</li></ol>
+<ol start='1860'><li title='1860'>壱阡八百六拾、</li></ol>
+<ol start='1865'><li title='1865'>壱阡八百六拾伍、</li></ol>
+<ol start='5865'><li title='5865'>伍阡八百六拾伍、</li></ol>
+<ol start='7005'><li title='7005'>七阡伍、</li></ol>
+<ol start='7800'><li title='7800'>七阡八百、</li></ol>
+<ol start='7865'><li title='7865'>七阡八百六拾伍、</li></ol>
+<ol start='9999'><li title='9999'>九阡九百九拾九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-049.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-049.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-formal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-050.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-050.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-formal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">マイナス十一、</li><li title="-10">マイナス十、</li><li title="-9">マイナス九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-051.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-051.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>japanese-formal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: japanese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>壱、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-052.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-052.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hangul-formal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hangul-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>영、</li></ol>
+<ol start='1'><li title='1'>일、</li></ol>
+<ol start='2'><li title='2'>이、</li></ol>
+<ol start='3'><li title='3'>삼、</li></ol>
+<ol start='4'><li title='4'>사、</li></ol>
+<ol start='5'><li title='5'>오、</li></ol>
+<ol start='6'><li title='6'>육、</li></ol>
+<ol start='7'><li title='7'>칠、</li></ol>
+<ol start='8'><li title='8'>팔、</li></ol>
+<ol start='9'><li title='9'>구、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-053.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-053.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hangul-formal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hangul-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>일십、</li></ol>
+<ol start='11'><li title='11'>일십일、</li></ol>
+<ol start='12'><li title='12'>일십이、</li></ol>
+<ol start='43'><li title='43'>사십삼、</li></ol>
+<ol start='77'><li title='77'>칠십칠、</li></ol>
+<ol start='80'><li title='80'>팔십、</li></ol>
+<ol start='99'><li title='99'>구십구、</li></ol>
+<ol start='100'><li title='100'>일백、</li></ol>
+<ol start='101'><li title='101'>일백일、</li></ol>
+<ol start='222'><li title='222'>이백이십이、</li></ol>
+<ol start='540'><li title='540'>오백사십、</li></ol>
+<ol start='999'><li title='999'>구백구십구、</li></ol>
+<ol start='1000'><li title='1000'>일천、</li></ol>
+<ol start='1005'><li title='1005'>일천오、</li></ol>
+<ol start='1060'><li title='1060'>일천육십、</li></ol>
+<ol start='1065'><li title='1065'>일천육십오、</li></ol>
+<ol start='1800'><li title='1800'>일천팔백、</li></ol>
+<ol start='1860'><li title='1860'>일천팔백육십、</li></ol>
+<ol start='1865'><li title='1865'>일천팔백육십오、</li></ol>
+<ol start='5865'><li title='5865'>오천팔백육십오、</li></ol>
+<ol start='7005'><li title='7005'>칠천오、</li></ol>
+<ol start='7800'><li title='7800'>칠천팔백、</li></ol>
+<ol start='7865'><li title='7865'>칠천팔백육십오、</li></ol>
+<ol start='9999'><li title='9999'>구천구백구십구、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-054.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-054.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hangul-formal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hangul-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">10000.</li><li title="10001">10001.</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-055.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-055.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hangul-formal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hangul-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">-일십일、</li><li title="-10">-일십、</li><li title="-9">-구、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-056.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-056.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hangul-formal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hangul-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>일、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-057.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-057.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-informal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>一、</li></ol>
+<ol start='2'><li title='2'>二、</li></ol>
+<ol start='3'><li title='3'>三、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>五、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-058.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-058.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-informal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>十、</li></ol>
+<ol start='11'><li title='11'>十一、</li></ol>
+<ol start='12'><li title='12'>十二、</li></ol>
+<ol start='43'><li title='43'>四十三、</li></ol>
+<ol start='77'><li title='77'>七十七、</li></ol>
+<ol start='80'><li title='80'>八十、</li></ol>
+<ol start='99'><li title='99'>九十九、</li></ol>
+<ol start='100'><li title='100'>百、</li></ol>
+<ol start='101'><li title='101'>百一、</li></ol>
+<ol start='222'><li title='222'>二百二十二、</li></ol>
+<ol start='540'><li title='540'>五百四十、</li></ol>
+<ol start='999'><li title='999'>九百九十九、</li></ol>
+<ol start='1000'><li title='1000'>千、</li></ol>
+<ol start='1005'><li title='1005'>千五、</li></ol>
+<ol start='1060'><li title='1060'>千六十、</li></ol>
+<ol start='1065'><li title='1065'>千六十五、</li></ol>
+<ol start='1800'><li title='1800'>千八百、</li></ol>
+<ol start='1860'><li title='1860'>千八百六十、</li></ol>
+<ol start='1865'><li title='1865'>千八百六十五、</li></ol>
+<ol start='5865'><li title='5865'>五千八百六十五、</li></ol>
+<ol start='7005'><li title='7005'>七千五、</li></ol>
+<ol start='7800'><li title='7800'>七千八百、</li></ol>
+<ol start='7865'><li title='7865'>七千八百六十五、</li></ol>
+<ol start='9999'><li title='9999'>九千九百九十九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-059.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-059.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-informal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">10000.</li><li title="10001">10001.</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-060.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-060.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-informal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">-十一、</li><li title="-10">-十、</li><li title="-9">-九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-061.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-061.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-informal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>一、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-062.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-062.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-formal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>壹、</li></ol>
+<ol start='2'><li title='2'>貳、</li></ol>
+<ol start='3'><li title='3'>參、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>五、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-063.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-063.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-formal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>壹拾、</li></ol>
+<ol start='11'><li title='11'>壹拾壹、</li></ol>
+<ol start='12'><li title='12'>壹拾貳、</li></ol>
+<ol start='43'><li title='43'>四拾參、</li></ol>
+<ol start='77'><li title='77'>七拾七、</li></ol>
+<ol start='80'><li title='80'>八拾、</li></ol>
+<ol start='99'><li title='99'>九拾九、</li></ol>
+<ol start='100'><li title='100'>壹百、</li></ol>
+<ol start='101'><li title='101'>壹百壹、</li></ol>
+<ol start='222'><li title='222'>貳百貳拾貳、</li></ol>
+<ol start='540'><li title='540'>五百四拾、</li></ol>
+<ol start='999'><li title='999'>九百九拾九、</li></ol>
+<ol start='1000'><li title='1000'>壹仟、</li></ol>
+<ol start='1005'><li title='1005'>壹仟五、</li></ol>
+<ol start='1060'><li title='1060'>壹仟六拾、</li></ol>
+<ol start='1065'><li title='1065'>壹仟六拾五、</li></ol>
+<ol start='1800'><li title='1800'>壹仟八百、</li></ol>
+<ol start='1860'><li title='1860'>壹仟八百六拾、</li></ol>
+<ol start='1865'><li title='1865'>壹仟八百六拾五、</li></ol>
+<ol start='5865'><li title='5865'>五仟八百六拾五、</li></ol>
+<ol start='7005'><li title='7005'>七仟五、</li></ol>
+<ol start='7800'><li title='7800'>七仟八百、</li></ol>
+<ol start='7865'><li title='7865'>七仟八百六拾五、</li></ol>
+<ol start='9999'><li title='9999'>九仟九百九拾九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-064.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-064.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-formal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">10000.</li><li title="10001">10001.</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-065.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-065.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-formal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">-壹拾壹、</li><li title="-10">-壹拾、</li><li title="-9">-九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-066.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-066.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>korean-hanja-formal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: korean-hanja-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>壹、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-068.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-068.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>ethiopic-numeric, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: ethiopic-numeric;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class='test'><ol>
+				<li title='1'>፩.</li>
+				<li title='2'>፪.</li>
+				<li title='3'>፫.</li>
+				<li title='4'>፬.</li>
+				<li title='5'>፭.</li>
+				<li title='6'>፮.</li>
+				<li title='7'>፯.</li>
+				<li title='8'>፰.</li>
+				<li title='9'>፱.</li>
+			</ol>
+			</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-069.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-069.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>ethiopic-numeric, 10+</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: ethiopic-numeric;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class='test'><ol start='10'>
+				<li title='10'>፲.</li>
+				<li title='11'>፲፩.</li>
+				<li title='12'>፲፪.</li>
+			</ol>
+
+			<ol start='43'>
+				<li title='43'>፵፫.</li>
+			</ol>
+			<ol start='77'>
+				<li title='77'>፸፯.</li>
+			</ol>
+			<ol start='80'>
+
+				<li title='80'>፹.</li>
+			</ol>
+			<ol start='99'>
+				<li title='99'>፺፱.</li>
+				<li title='100'>፻.</li>
+				<li title='101'>፻፩.</li>
+
+			</ol>
+			<ol start='222'>
+				<li title='222'>፪፻፳፪.</li>
+			</ol>
+			<ol start='540'>
+				<li title='540'>፭፻፵.</li>
+			</ol>
+
+			<ol start='999'>
+				<li title='999'>፱፻፺፱.</li>
+				<li title='1000'>፲፻.</li>
+			</ol>
+			<ol start='1005'>
+				<li title='1005'>፲፻፭.</li>
+
+			</ol>
+			<ol start='1060'>
+				<li title='1060'>፲፻፷.</li>
+			</ol>
+			<ol start='1065'>
+				<li title='1065'>፲፻፷፭.</li>
+			</ol>
+
+			<ol start='1800'>
+				<li title='1800'>፲፰፻.</li>
+			</ol>
+			<ol start='1860'>
+				<li title='1860'>፲፰፻፷.</li>
+			</ol>
+			<ol start='1865'>
+
+				<li title='1865'>፲፰፻፷፭.</li>
+			</ol>
+			<ol start='5865'>
+				<li title='5865'>፶፰፻፷፭.</li>
+			</ol>
+			<ol start='7005'>
+				<li title='7005'>፸፻፭.</li>
+
+			</ol>
+			<ol start='7800'>
+				<li title='7800'>፸፰፻.</li>
+			</ol>
+			<ol start='7864'>
+				<li title='7864'>፸፰፻፷፬.</li>
+			</ol>
+
+			<ol start='9999'>
+				<li title='9999'>፺፱፻፺፱.</li>
+				<li title='10000'>፼፻.</li>
+			</ol>
+			<ol start='78010092'>
+				<li title='78010092'>፸፰፻፩፼፻፺፪.</li>
+			</ol>
+			<ol start='1000001'>
+				<li title='1000001'>፻፼፻፩.</li>
+			</ol>
+			</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-070.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-070.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>ethiopic-numeric, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: ethiopic-numeric;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class='test'>
+			<ol start='1'>
+				<li title='1'>፩.</li>
+			</ol>
+			</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-071.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-071.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-informal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>一、</li></ol>
+<ol start='2'><li title='2'>二、</li></ol>
+<ol start='3'><li title='3'>三、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>五、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-072.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-072.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-informal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>十、</li></ol>
+<ol start='11'><li title='11'>十一、</li></ol>
+<ol start='12'><li title='12'>十二、</li></ol>
+<ol start='43'><li title='43'>四十三、</li></ol>
+<ol start='77'><li title='77'>七十七、</li></ol>
+<ol start='80'><li title='80'>八十、</li></ol>
+<ol start='99'><li title='99'>九十九、</li></ol>
+<ol start='100'><li title='100'>一百、</li></ol>
+<ol start='101'><li title='101'>一百零一、</li></ol>
+<ol start='222'><li title='222'>二百二十二、</li></ol>
+<ol start='540'><li title='540'>五百四十、</li></ol>
+<ol start='999'><li title='999'>九百九十九、</li></ol>
+<ol start='1000'><li title='1000'>一千、</li></ol>
+<ol start='1005'><li title='1005'>一千零五、</li></ol>
+<ol start='1060'><li title='1060'>一千零六十、</li></ol>
+<ol start='1065'><li title='1065'>一千零六十五、</li></ol>
+<ol start='1800'><li title='1800'>一千八百、</li></ol>
+<ol start='1860'><li title='1860'>一千八百六十、</li></ol>
+<ol start='1865'><li title='1865'>一千八百六十五、</li></ol>
+<ol start='5865'><li title='5865'>五千八百六十五、</li></ol>
+<ol start='7005'><li title='7005'>七千零五、</li></ol>
+<ol start='7800'><li title='7800'>七千八百、</li></ol>
+<ol start='7865'><li title='7865'>七千八百六十五、</li></ol>
+<ol start='9999'><li title='9999'>九千九百九十九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-073.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-073.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-informal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-074.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-074.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-informal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">负壹拾壹、</li><li title="-10">负壹拾、</li><li title="-9">负九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-075.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-075.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-informal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>一、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-076.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-076.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-formal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>壹、</li></ol>
+<ol start='2'><li title='2'>贰、</li></ol>
+<ol start='3'><li title='3'>叁、</li></ol>
+<ol start='4'><li title='4'>肆、</li></ol>
+<ol start='5'><li title='5'>伍、</li></ol>
+<ol start='6'><li title='6'>陆、</li></ol>
+<ol start='7'><li title='7'>柒、</li></ol>
+<ol start='8'><li title='8'>捌、</li></ol>
+<ol start='9'><li title='9'>玖、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-077.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-077.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-formal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>壹拾、</li></ol>
+<ol start='11'><li title='11'>壹拾壹、</li></ol>
+<ol start='12'><li title='12'>壹拾贰、</li></ol>
+<ol start='43'><li title='43'>肆拾叁、</li></ol>
+<ol start='77'><li title='77'>柒拾柒、</li></ol>
+<ol start='80'><li title='80'>捌拾、</li></ol>
+<ol start='99'><li title='99'>玖拾玖、</li></ol>
+<ol start='100'><li title='100'>壹佰、</li></ol>
+<ol start='101'><li title='101'>壹佰零壹、</li></ol>
+<ol start='222'><li title='222'>贰佰贰拾贰、</li></ol>
+<ol start='540'><li title='540'>伍佰肆拾、</li></ol>
+<ol start='999'><li title='999'>玖佰玖拾玖、</li></ol>
+<ol start='1000'><li title='1000'>壹仟、</li></ol>
+<ol start='1005'><li title='1005'>壹仟零伍、</li></ol>
+<ol start='1060'><li title='1060'>壹仟零陆拾、</li></ol>
+<ol start='1065'><li title='1065'>壹仟零陆拾伍、</li></ol>
+<ol start='1800'><li title='1800'>壹仟捌佰、</li></ol>
+<ol start='1860'><li title='1860'>壹仟捌佰陆拾、</li></ol>
+<ol start='1865'><li title='1865'>壹仟捌佰陆拾伍、</li></ol>
+<ol start='5865'><li title='5865'>伍仟捌佰陆拾伍、</li></ol>
+<ol start='7005'><li title='7005'>柒仟零伍、</li></ol>
+<ol start='7800'><li title='7800'>柒仟捌佰、</li></ol>
+<ol start='7865'><li title='7865'>柒仟捌佰陆拾伍、</li></ol>
+<ol start='9999'><li title='9999'>玖仟玖佰玖拾玖、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-078.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-078.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-formal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-079.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-079.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-formal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">负壹拾壹、</li><li title="-10">负壹拾、</li><li title="-9">负九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-080.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-080.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>simp-chinese-formal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: simp-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>壹、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-081.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-081.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-informal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>一、</li></ol>
+<ol start='2'><li title='2'>二、</li></ol>
+<ol start='3'><li title='3'>三、</li></ol>
+<ol start='4'><li title='4'>四、</li></ol>
+<ol start='5'><li title='5'>五、</li></ol>
+<ol start='6'><li title='6'>六、</li></ol>
+<ol start='7'><li title='7'>七、</li></ol>
+<ol start='8'><li title='8'>八、</li></ol>
+<ol start='9'><li title='9'>九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-082.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-082.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-informal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>十、</li></ol>
+<ol start='11'><li title='11'>十一、</li></ol>
+<ol start='12'><li title='12'>十二、</li></ol>
+<ol start='43'><li title='43'>四十三、</li></ol>
+<ol start='77'><li title='77'>七十七、</li></ol>
+<ol start='80'><li title='80'>八十、</li></ol>
+<ol start='99'><li title='99'>九十九、</li></ol>
+<ol start='100'><li title='100'>一百、</li></ol>
+<ol start='101'><li title='101'>一百零一、</li></ol>
+<ol start='222'><li title='222'>二百二十二、</li></ol>
+<ol start='540'><li title='540'>五百四十、</li></ol>
+<ol start='999'><li title='999'>九百九十九、</li></ol>
+<ol start='1000'><li title='1000'>一千、</li></ol>
+<ol start='1005'><li title='1005'>一千零五、</li></ol>
+<ol start='1060'><li title='1060'>一千零六十、</li></ol>
+<ol start='1065'><li title='1065'>一千零六十五、</li></ol>
+<ol start='1800'><li title='1800'>一千八百、</li></ol>
+<ol start='1860'><li title='1860'>一千八百六十、</li></ol>
+<ol start='1865'><li title='1865'>一千八百六十五、</li></ol>
+<ol start='5865'><li title='5865'>五千八百六十五、</li></ol>
+<ol start='7005'><li title='7005'>七千零五、</li></ol>
+<ol start='7800'><li title='7800'>七千八百、</li></ol>
+<ol start='7865'><li title='7865'>七千八百六十五、</li></ol>
+<ol start='9999'><li title='9999'>九千九百九十九、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-083.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-083.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-informal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-084.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-084.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-informal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">負壹拾壹、</li><li title="-10">負壹拾、</li><li title="-9">負九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-085.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-085.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-informal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-informal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>一、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-086.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-086.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-formal, 0-9</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='0'><li title='0'>零、</li></ol>
+<ol start='1'><li title='1'>壹、</li></ol>
+<ol start='2'><li title='2'>貳、</li></ol>
+<ol start='3'><li title='3'>參、</li></ol>
+<ol start='4'><li title='4'>肆、</li></ol>
+<ol start='5'><li title='5'>伍、</li></ol>
+<ol start='6'><li title='6'>陸、</li></ol>
+<ol start='7'><li title='7'>柒、</li></ol>
+<ol start='8'><li title='8'>捌、</li></ol>
+<ol start='9'><li title='9'>玖、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-087.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-087.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-formal, 10-9999</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start='10'><li title='10'>壹拾、</li></ol>
+<ol start='11'><li title='11'>壹拾壹、</li></ol>
+<ol start='12'><li title='12'>壹拾貳、</li></ol>
+<ol start='43'><li title='43'>肆拾參、</li></ol>
+<ol start='77'><li title='77'>柒拾柒、</li></ol>
+<ol start='80'><li title='80'>捌拾、</li></ol>
+<ol start='99'><li title='99'>玖拾玖、</li></ol>
+<ol start='100'><li title='100'>壹佰、</li></ol>
+<ol start='101'><li title='101'>壹佰零壹、</li></ol>
+<ol start='222'><li title='222'>貳佰貳拾貳、</li></ol>
+<ol start='540'><li title='540'>伍佰肆拾、</li></ol>
+<ol start='999'><li title='999'>玖佰玖拾玖、</li></ol>
+<ol start='1000'><li title='1000'>壹仟、</li></ol>
+<ol start='1005'><li title='1005'>壹仟零伍、</li></ol>
+<ol start='1060'><li title='1060'>壹仟零陸拾、</li></ol>
+<ol start='1065'><li title='1065'>壹仟零陸拾伍、</li></ol>
+<ol start='1800'><li title='1800'>壹仟捌佰、</li></ol>
+<ol start='1860'><li title='1860'>壹仟捌佰陸拾、</li></ol>
+<ol start='1865'><li title='1865'>壹仟捌佰陸拾伍、</li></ol>
+<ol start='5865'><li title='5865'>伍仟捌佰陸拾伍、</li></ol>
+<ol start='7005'><li title='7005'>柒仟零伍、</li></ol>
+<ol start='7800'><li title='7800'>柒仟捌佰、</li></ol>
+<ol start='7865'><li title='7865'>柒仟捌佰陸拾伍、</li></ol>
+<ol start='9999'><li title='9999'>玖仟玖佰玖拾玖、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-088.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-088.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-formal, outside range</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="10000"><li title="10000">一〇〇〇〇、</li><li title="10001">一〇〇〇一、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-089.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-089.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-formal, negative</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two columns are the same, ignoring the suffix.</p>
+
+
+<div class="test"><ol start="-11"><li title="-11">負壹拾壹、</li><li title="-10">負壹拾、</li><li title="-9">負九、</li></ol></div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-090.html
+++ b/contributors/i18n/submitted/css3-counter-styles/css3-counter-styles-090.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>trad-chinese-formal, suffix</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
+<meta name='flags' content='font'>
+<style type='text/css'>
+.test { font-size: 25px; }
+ol { margin: 0; padding-left: 8em; }
+ol li { list-style-type: trad-chinese-formal;  }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the suffix in each of the two columns is the same, ignoring the actual numbers.</p>
+
+
+<div class="test"><ol start='1'><li title='1'>壹、</li></ol>
+</div>
+
+
+<!--Notes:
+You will need an appropriate font to run this test.
+
+To see the ASCII decimal number associated with a row, mouse over it and the number will pop up in a tooltip.
+-->
+
+
+</body>
+</html>


### PR DESCRIPTION
This set of tests is exported to flat files from the i18n test framework. To see the tests and results in that framework see http://www.w3.org/International/tests/html5/css3-counter-styles/results-cstyles

I have submitted these as manual tests rather than reftests, because I don't know how to replicate the auto-numbered part of the list to pixel-perfection.  (If someone can tell me how to do that, and has checked that it really works, I'd be willing to update the tests to full reftest.  Note, that these tests use a wide range of unicode characters, of necessity, so ahem and even downloadable fonts are not very helpful afaict.)
