### PR TITLE
New tests for language selectors in CSS3 Selectors

### DIFF
--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-001.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box:lang(es) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value that matches an identical lang attribute value on the same element will produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-002.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), lang="es" on parent</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box:lang(es) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test" lang="es"><div id="box">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value that matches an identical lang attribute value on a parent element will produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-004.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-004.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), lang="ES"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(es) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value will match a lang attribute value regardless of case differences.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-005.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-005.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), lang="es-MX"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(es) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value will match a lang attribute value when the latter contains additional subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-006.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-006.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es-MX), lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(es-MX) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A :lang value will NOT match a lang attribute value when the former contains more subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-007.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-007.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), lang="mx-es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(es-MX) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "When the :lang value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-008.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-008.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(en-GB), lang="en-GB"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(en-GB) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value with language and region subtags will match a lang attribute value with the same subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-009.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-009.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(en-GB), lang="en-GB-scouse"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(en-GB) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value with a multiple subtags will match a lang attribute value with multiple subtags as long as the first part is the same.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-010.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-010.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(en-GB), lang="en-US"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(en-GB) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A :lang value and a lang attribute value will NOT match if their region subtags differ.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-011.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-011.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(az-Arab-IR), lang="az-Arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(az-Arab-IR) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value with language, script and region subtags will match a lang attribute value with the same language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-012.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-012.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(az-Arab-IR), lang="az-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(az-Arab-IR) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A :lang value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-014.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-014.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(cs-CZ), lang="cs-Latn-CZ"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(cs-CZ) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A :lang value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-015.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-015.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(az-Arab-IR), lang="az-arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(az-Arab-IR) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A :lang value will match a lang attribute value regardless of case differences in the script tag.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-016.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-016.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>:lang(es), xml:lang="es" (html)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/Overview.html#lang-pseudo'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest:lang(xx) { display:none; } 
+#box:lang(es) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to :lang support. If :lang is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A :lang value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-021.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-021.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang|='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value that matches an identical lang attribute value on the same element will produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-022.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-022.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], lang="es" on parent</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang|='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test" lang="es"><div id="box">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value that matches an identical lang attribute value on the parent element will NOT produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-024.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-024.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], lang="ES"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value will match a lang attribute value regardless of case differences.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-025.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-025.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], lang="es-MX"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value will match a lang attribute value when the latter contains additional subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-026.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-026.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es-MX"], lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es-MX'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value will NOT match a lang attribute value when the former contains more subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-027.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-027.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], lang="mx-es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "When the lang|= value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-028.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-028.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="en-GB"], lang="en-GB"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='en-GB'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value with language and region subtags will match a lang attribute value with the same subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-029.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-029.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="en-GB"], lang="en-GB-scouse"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='en-GB'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value with a multiple subtags will match a lang attribute value with multiple subtags as long as the first part is the same.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-030.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-030.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="en-GB"], lang="en-US"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es-GB'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value and a lang attribute value will NOT match if their region subtags differ.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-031.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-031.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="az-Arab-IR"], lang="az-Arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='az-Arab-IR'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value with language, script and region subtags will match a lang attribute value with the same language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-032.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-032.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="az-Arab-IR"], lang="az-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='az-Arab-IR'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-034.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-034.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="cs-CZ"], lang="cs-Latn-CZ"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='cs-CZ'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-035.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-035.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="az-Arab-IR"], lang="az-arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='az-Arab-IR'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang|= value will match a lang attribute value regardless of case differences in the script tag.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-036.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-036.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang|="es"], xml:lang="es" (html)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+ 		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+		#colonlangcontroltest[lang|=xx] { display:none; } 
+#box[lang|='es'] { width: 100px; }
+#relevance[lang|='yy'] { display:none; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
+
+
+<!--Notes:
+This tests a detail related to [lang|=..] support. If [lang|=..] is not supported, a message will appear and the test will fail.
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A [lang|='es'] value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-041.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-041.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang= value that matches an identical lang attribute value on the same element will produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-042.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-042.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], lang="es" on parent</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test" lang="es"><div id="box">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang|= value that matches an identical lang attribute value on the parent element will NOT produce styling.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-044.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-044.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], lang="ES"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang= value will match a lang attribute value regardless of case differences.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-045.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-045.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], lang="es-MX"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value will NOT match a lang attribute value when the latter contains additional subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-046.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-046.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es-MX"], lang="es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es-MX'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value will NOT match a lang attribute value when the former contains more subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-047.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-047.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], lang="mx-es"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "When the lang= value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-048.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-048.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="en-GB"], lang="en-GB"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='en-GB'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang= value with language and region subtags will match a lang attribute value with the same subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-049.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-049.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="en-GB"], lang="en-GB-scouse"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='en-GB'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value with multiple subtags will NOT match a lang attribute value with multiple subtags if the latter has more subtags, even if the first two subtags are the same.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-050.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-050.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="en-GB"], lang="en-US"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='en-GB'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value and a lang attribute value will NOT match if their region subtags differ.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-051.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-051.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="az-Arab-IR"], lang="az-Arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='az-Arab-IR'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang= value with language, script and region subtags will match a lang attribute value with the same language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-052.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-052.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="az-Arab-IR"], lang="az-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='az-Arab-IR'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-054.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-054.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="cs-CZ"], lang="cs-Latn-CZ"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='cs-CZ'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A lang= value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-055.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-055.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="az-Arab-IR"], lang="az-arab-IR"</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='az-Arab-IR'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "A lang= value will match a lang attribute value regardless of case differences in the script tag.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-056.html
+++ b/contributors/i18n/submitted/css3-selectors/css3-selectors-lang-056.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>[lang="es"], xml:lang="es" (html)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/selectors/#attribute-selectors'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='HTMLonly'>
+<style type='text/css'>
+.test div { width: 50px; }
+#box[lang='es'] { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "A [lang='es'] value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>


### PR DESCRIPTION
These tests and test results can be seen in the i18n test framework at http://www.w3.org/International/tests/html5/css3-selectors-lang/results-lang#colonlang
