### PR TITLE
[TTWF Shanghai]Tests for css3 box shadow from Mark

### DIFF
--- a/contributors/ttwf_shanghai/css3-background/mark/submitted/css3-box-shadow-outline.html
+++ b/contributors/ttwf_shanghai/css3-background/mark/submitted/css3-box-shadow-outline.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Test box-shadow and outline</title>
+  <link rel="author" title="mark" href="mailto:markje@live.cn">
+  <link rel="help" href="http://dev.w3.org/csswg/css-backgrounds/#the-box-shadow" />
+  <link rel="match" href="reference/css3-box-shadow-outline-ref.html">
+  <meta name="assert" content="There should be no green shadow." />
+  <style>
+    .test_backG {
+      width: 200px;
+      height: 200px;
+      box-shadow: 10px 10px 0 green;
+      outline: solid yellow 10px;
+      background: #999;
+    }
+  </style>
+</head>
+<body>
+  <p>There should be no green shadow.</p>
+  <div class="test_backG"></div>
+</body>
+</html>

--- a/contributors/ttwf_shanghai/css3-background/mark/submitted/reference/css3-box-shadow-outline-ref.html
+++ b/contributors/ttwf_shanghai/css3-background/mark/submitted/reference/css3-box-shadow-outline-ref.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Test box-shadow and outline</title>
+  <link rel="author" title="mark" href="mailto:markje@live.cn">
+  <link rel="help" href="http://dev.w3.org/csswg/css-backgrounds/#the-box-shadow" />
+  <style>
+    .test_backG {
+      width: 200px;
+      height: 200px;
+      outline: solid yellow 10px;
+      position: relative;
+      background: #999;
+    }
+  </style>
+</head>
+<body>
+  <p>There should be no green shadow.</p>
+  <div class="test_backG"></div>
+</body>
+</html>


### PR DESCRIPTION
Reviewed by @ArchangelSDY at TestTWF Shanghai, still need work:
1. It seems to be more like a test for outline than box-shadow.
2. I'm not sure if any spec has defined the right behavior for an UA in this situation. Here's a related bug for
   Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=480888.
