### PR TITLE
Fix layering problem with refs

### DIFF
--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-circle-000-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-circle-000-ref.html
@@ -21,12 +21,14 @@
 
 #left-circle-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-circle-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-ellipse-000-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-ellipse-000-ref.html
@@ -21,12 +21,14 @@
 
 #left-ellipse-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-ellipse-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-inset-rectangle-001-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-inset-rectangle-001-ref.html
@@ -21,12 +21,14 @@
 
 #left-rounded-rect-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-rounded-rect-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-001-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-001-ref.html
@@ -22,12 +22,14 @@
 
 #left-rounded-rect-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-rounded-rect-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-002-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-002-ref.html
@@ -22,12 +22,14 @@
 
 #left-rounded-rect-circle-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-rounded-rect-circle-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-003-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-003-ref.html
@@ -22,12 +22,14 @@
 
 #left-rounded-rect-ellipse-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     left: 0px;
 }
 
 #right-rounded-rect-ellipse-outline {
     position: absolute;
+    z-index: -1;
     top: 20px;
     right: 0px;
 }

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-004-ref.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-004-ref.html
@@ -6,25 +6,26 @@
 <style>
 .container {
     position: relative;
-    font: 10px/1 Ahem, sans-serif;
-    width: 80px;
-    height: 40px;
-    border: 1px solid black;
+    font: 20px/1 Ahem, sans-serif;
+    line-height: 20px;
+    width: 160px;
+    height: 80px;
     margin: 5px;
 }
 .rounded-rect {
     position: absolute;
+    z-index: -1;
     top: 0px;
     left: 0px;
-    width: 40px;
-    height: 40px;
+    width: 80px;
+    height: 80px;
     border: 1px solid blue;
     border-radius: 50%;
 }
 .left-rounded-rect-float-line {
     float: left;
     clear: left;
-    height: 10px;
+    height: 20px;
 }
 </style>
 <body>
@@ -59,37 +60,35 @@
     <script src="resources/rounded-rectangle.js"></script>
     <script src="resources/subpixel-utils.js"></script>
     <script>
-    // Note that the border must be added into the width to account for its
-    // affect on float positioning.
     genLeftRoundedRectFloatShapeOutsideRefTest({
-        roundedRect: {x: 0, y: 0, width: 41, height: 40, rx: 20, ry: 20},
-        containerWidth: 80, 
-        containerHeight: 40,
-        lineHeight: 10,
+        roundedRect: {x: 0, y: 0, width: 81, height: 80, rx: 40, ry: 40},
+        containerWidth: 160,
+        containerHeight: 80,
+        lineHeight: 20,
         floatElementClassSuffix: "rounded-rect-float-line",
         insertElementIdSuffix: "fixed-units"
     });
     genLeftRoundedRectFloatShapeOutsideRefTest({
-        roundedRect: {x: 0, y: 0, width: 41, height: 40, rx: 20, ry: 20},
-        containerWidth: 80, 
-        containerHeight: 40,
-        lineHeight: 10,
+        roundedRect: {x: 0, y: 0, width: 81, height: 80, rx: 40, ry: 40},
+        containerWidth: 160,
+        containerHeight: 80,
+        lineHeight: 20,
         floatElementClassSuffix: "rounded-rect-float-line",
         insertElementIdSuffix: "relative-units"
     });
     genLeftRoundedRectFloatShapeOutsideRefTest({
-        roundedRect: {x: 0, y: 0, width: 41, height: 40, rx: 20, ry: 20},
-        containerWidth: 80, 
-        containerHeight: 40,
-        lineHeight: 10,
+        roundedRect: {x: 0, y: 0, width: 81, height: 80, rx: 40, ry: 40},
+        containerWidth: 160,
+        containerHeight: 80,
+        lineHeight: 20,
         floatElementClassSuffix: "rounded-rect-float-line",
         insertElementIdSuffix: "different-units"
     });
     genLeftRoundedRectFloatShapeOutsideRefTest({
-        roundedRect: {x: 0, y: 0, width: 41, height: 40, rx: 20, ry: 20},
-        containerWidth: 80, 
-        containerHeight: 40,
-        lineHeight: 10,
+        roundedRect: {x: 0, y: 0, width: 81, height: 80, rx: 40, ry: 40},
+        containerWidth: 160,
+        containerHeight: 80,
+        lineHeight: 20,
         floatElementClassSuffix: "rounded-rect-float-line",
         insertElementIdSuffix: "edge-case"
     });

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-004.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-rounded-rectangle-004.html
@@ -7,24 +7,24 @@
 <meta name="flags" content="ahem">
 <style>
 .container {
-    font: 10px/1 Ahem, sans-serif;
-    width: 80px;
-    height: 40px;
-    border: 1px solid black;
+    font: 20px/1 Ahem, sans-serif;
+    line-height: 20px;
+    width: 160px;
+    height: 80px;
     margin: 5px;
 }
 .float {
     float: left;
-    width: 40px;
-    height: 40px;
+    width: 80px;
+    height: 80px;
     border: 1px solid blue;
     border-radius: 50%;
 }
 .fixed-units {
-    shape-outside: rectangle(0px, 0px, 40px, 40px, 40px, 40px);
+    shape-outside: rectangle(0px, 0px, 80px, 80px, 80px, 80px);
 }
 .different-units {
-    shape-outside: rectangle(0px, 0px, 40px, 40px, 100%, 100%);
+    shape-outside: rectangle(0px, 0px, 80px, 80px, 100%, 100%);
 }
 .relative-units {
     shape-outside: rectangle(0px, 0px, 100%, 100%, 700em, 700em);

--- a/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-stacked-000.html
+++ b/contributors/adobe/submitted/shapes/shape-outside/shape-outside-floats-stacked-000.html
@@ -14,6 +14,7 @@
     background-color: red;
     margin-bottom: 50px;
     overflow: hidden;
+    color: green;
 }
 .float-left {
     width: 100px;


### PR DESCRIPTION
The WebKit/Blink implementations had a bug where a float with shape
outside was creating a new layer, causing it to paint on top of adjacent
text. Fixing this bug showcased the bugs in these tests.
