### PR TITLE
Add parsing tests for basic shapes for CSS Shapes Specification

### DIFF
--- a/contributors/adobe/submitted/shapes/basic-shapes/resources/parsing-utils.js
+++ b/contributors/adobe/submitted/shapes/basic-shapes/resources/parsing-utils.js
@@ -1,0 +1,43 @@
+function test_inline_style(value, expected) {
+    var div = document.createElement('div');
+    div.style.setProperty('shape-outside', value);
+    var actual = div.style.getPropertyValue('shape-outside');
+    assert_equals(actual, typeof expected !== 'undefined' ? expected : value);
+}
+
+function test_computed_style(value, expected, props) {
+    var div = document.createElement('div');
+    div.style.setProperty('shape-outside', value);
+    if (props)
+        for (key in props)
+            div.style.setProperty(key, props[key]);
+    document.body.appendChild(div);
+    var style = getComputedStyle(div);
+    var actual = style.getPropertyValue('shape-outside');
+    document.body.removeChild(div);
+    assert_equals(actual, typeof expected !== 'undefined' ? expected : value);
+}
+
+function test_approx_computed_style(value, expected, props) {
+    var div = document.createElement('div');
+    div.style.setProperty('shape-outside', value);
+    if (props)
+        for (key in props)
+            div.style.setProperty(key, props[key]);
+    document.body.appendChild(div);
+    var numre = /[\d\.]+/g;
+
+    var result = getComputedStyle(div).getPropertyValue('shape-outside');
+    document.body.removeChild(div);
+
+    // Is it the same except for the numbers?
+    assert_equals(result.replace(numre, ''), expected.replace(numre, ''));
+
+    // Are the numbers equal?
+    var results = result.match(numre).map(parseFloat);
+    var expecteds = expected.match(numre).map(parseFloat);
+    assert_equals(results.length, expecteds.length);
+    results.forEach(function(result, i) {
+        assert_approx_equals(result, expecteds[i], 0.01);
+    });
+}

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-circle-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-circle-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Circle Inline Style Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#circle">
+        <meta name="assert" content="A circular basic shape has 3 length or percentage arguments">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["3 length arguments", "circle(1px, 2px, 3px)"],
+                ["3 percentage arguments", "circle(1%, 2%, 3%)"],
+                ["Too few arguments", "circle(1px, 2px)", null],
+                ["Too many arguments", "circle(1px, 2px, 3px, 4px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-circle-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-circle-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Circle Invalid Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#circle">
+        <meta name="assert" content="A circular basic shape's radius cannot be negative">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["Invalid r", "circle(1px, 2px, -3px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-000.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Basic Shape Computed Font Relative Lengths</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#shape-outside-property">
+        <link rel="help" href="http://dev.w3.org/csswg/css-cascade/#computed">
+        <meta name="assert" content="The basic shape can contain relative length formats, which resolve to the computed (absolute) length value">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            // font relative units: em, ex, ch, rem
+            var units = ['em', 'ex', 'ch', 'rem'];
+            var div = document.createElement('div');
+            document.body.appendChild(div);
+            var resolveds = {};
+            units.forEach(function(unit) {
+                div.style.width = '1' + unit;
+                var s = getComputedStyle(div);
+                resolveds[unit] = parseFloat(s.width);
+            });
+            document.body.removeChild(div);
+
+            function fillArray(string, length) {
+                return Array.apply(null, new Array(length)).map(String.prototype.valueOf, string);
+            }
+
+            function testUnit(unit) {
+                var relativeLength = '1' + unit;
+                var usedLength = resolveds[unit] + 'px';
+
+                var input = 'circle(' + fillArray('1' + unit, 3).join(', ') + ')';
+                var output = 'circle(' + fillArray(resolveds[unit] + 'px', 3).join(', ') + ')';
+
+                test_computed_style(input, output);
+            }
+
+            var tests = units.map(function(unit) {
+                return [unit + ' units', unit];
+            });
+
+            generate_tests(testUnit, tests);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-001.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Basic Shape Computed Viewport Relative Lengths</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#shape-outside-property">
+        <link rel="help" href="http://dev.w3.org/csswg/css-cascade/#computed">
+        <meta name="assert" content="The basic shape can contain relative length formats, which resolve to the computed (absolute) length value">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            // viewport relative units: vw, vh, vmin, vmax
+            var units = ['vw', 'vh', 'vmin', 'vmax'];
+            var div = document.createElement('div');
+            document.body.appendChild(div);
+            var resolveds = {};
+            units.forEach(function(unit) {
+                div.style.width = '1' + unit;
+                var s = getComputedStyle(div);
+                resolveds[unit] = parseFloat(s.width);
+            });
+            document.body.removeChild(div);
+
+            function fillArray(string, length) {
+                return Array.apply(null, new Array(length)).map(String.prototype.valueOf, string);
+            }
+
+            function testUnit(unit) {
+                var relativeLength = '1' + unit;
+                var usedLength = resolveds[unit] + 'px';
+
+                var input = 'circle(' + fillArray('1' + unit, 3).join(', ') + ')';
+                var output = 'circle(' + fillArray(resolveds[unit] + 'px', 3).join(', ') + ')';
+
+                test_computed_style(input, output);
+            }
+
+            var tests = units.map(function(unit) {
+                return [unit + ' units', unit];
+            });
+
+            generate_tests(testUnit, tests);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-002.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-computed-shape-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Basic Shape Computed Percentage Lengths</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#shape-outside-property">
+        <link rel="help" href="http://dev.w3.org/csswg/css-cascade/#computed">
+        <meta name="assert" content="The basic shape can contain percentages, which remain unchanged when computed">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_computed_style, [[
+                "rectangle", "rectangle(10%, 20%, 30%, 40%, 50%, 60%)"
+            ], [
+                "inset-rectangle", "inset-rectangle(10%, 20%, 30%, 40%, 50%, 60%)"
+            ], [
+                "circle", "circle(10%, 20%, 30%)"
+            ], [
+                "ellipse", "ellipse(10%, 20%, 30%, 40%)"
+            ], [
+                "polygon", "polygon(nonzero, 10% 20%, 30% 40%, 50% 60%)"
+            ]]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-ellipse-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-ellipse-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Circle Inline Style Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#ellipse">
+        <meta name="assert" content="An elliptical basic shape has 4 length or percentage arguments">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["4 length arguments", "ellipse(1px, 2px, 3px, 4px)"],
+                ["4 percentage arguments", "ellipse(1%, 2%, 3%, 4%)"],
+                ["Too few arguments", "ellipse(1px, 2px, 3px)", null],
+                ["Too many arguments", "ellipse(1px, 2px, 3px, 4px, 5px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-ellipse-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-ellipse-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Circle Invalid Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#ellipse">
+        <meta name="assert" content="An elliptical basic shape's rx and ry values cannot be negative">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["Invalid rx", "ellipse(1px, 2px, -3px, 4px)", null],
+                ["Invalid ry", "ellipse(1px, 2px, 3px, -5px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-inset-rectangle-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-inset-rectangle-000.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Inset Rectangle Inline Style Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#inset-rectangle">
+        <meta name="assert" content="An inset-rectangle basic shape has 4-6 length or percentage arguments">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["4 length arguments", "inset-rectangle(1px, 2px, 3px, 4px)"],
+                ["5 length arguments", "inset-rectangle(1px, 2px, 3px, 4px, 5px)"],
+                ["6 length arguments", "inset-rectangle(1px, 2px, 3px, 4px, 5px, 6px)"],
+                ["4 percentage arguments", "inset-rectangle(1%, 2%, 3%, 4%)"],
+                ["5 percentage arguments", "inset-rectangle(1%, 2%, 3%, 4%, 5%)"],
+                ["6 percentage arguments", "inset-rectangle(1%, 2%, 3%, 4%, 5%, 6%)"],
+                ["Too few arguments", "inset-rectangle(1px, 2px, 3px)", null],
+                ["Too many arguments", "inset-rectangle(1px, 2px, 3px, 4px, 5px, 6px, 7px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-inset-rectangle-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-inset-rectangle-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Inset Rectangle Invalid Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#inset-rectangle">
+        <meta name="assert" content="No argument to inset-rectangle can be negative">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["Invalid top", "inset-rectangle(-1px, 2px, 3px, 4px)", null],
+                ["Invalid right", "inset-rectangle(1px, -2px, 3px, 4px)", null],
+                ["Invalid bottom", "rectangle(1px, 2px, -3px, 4px)", null],
+                ["Invalid left", "rectangle(1px, 2px, 3px, -4px)", null],
+                ["Invalid rx", "rectangle(1px, 2px, 3px, 4px, -5px, 6px)", null],
+                ["Invalid ry", "rectangle(1px, 2px, 3px, 4px, 5px, -6px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-polygon-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-polygon-000.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Polygon Inline Style Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#polygon">
+        <meta name="assert" content="A polygonal basic shape has an optional fill-rule and one or more pairs of coordinates">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["Too few points", "polygon()", null],
+                ["Clip-rule only is invalid", "polygon(evenodd)", null],
+                ["1 point only", "polygon(1px 2px)"],
+                ["Clip rule and point", "polygon(evenodd, 1px 2px)"],
+                ["Clip rule and multiple points", "polygon(nonzero, 1px 2px, 3px 4px)"],
+                ["Clip rule and multiple percentages", "polygon(evenodd, 1% 2%, 3% 4%)"],
+                ["No coordinates are paired", "polygon(1px, 2px, 3px, 4px)", null],
+                ["Not all coordinates are paired", "polygon(1px 2px, 3px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-rectangle-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-rectangle-000.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Rectangle Inline Style Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#rectangle">
+        <meta name="assert" content="A rectangular basic shape has 4-6 arguments">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["4 length arguments", "rectangle(1px, 2px, 3px, 4px)"],
+                ["5 length arguments", "rectangle(1px, 2px, 3px, 4px, 5px)"],
+                ["6 length arguments", "rectangle(1px, 2px, 3px, 4px, 5px, 6px)"],
+                ["4 percentage arguments", "rectangle(1%, 2%, 3%, 4%)"],
+                ["5 percentage arguments", "rectangle(1%, 2%, 3%, 4%, 5%)"],
+                ["6 percentage arguments", "rectangle(1%, 2%, 3%, 4%, 5%, 6%)"],
+                ["Too few arguments", "rectangle(1px, 2px, 3px)", null],
+                ["Too many arguments", "rectangle(1px, 2px, 3px, 4px, 5px, 6px, 7px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-rectangle-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-rectangle-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Rectangle Invalid Arguments</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#rectangle">
+        <meta name="assert" content="A rectangular basic shape cannot have negative width, height, rx, or ry">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["Invalid width", "rectangle(1px, 2px, -3px, 4px)", null],
+                ["Invalid height", "rectangle(1px, 2px, 3px, -4px)", null],
+                ["Invalid rx", "rectangle(1px, 2px, 3px, 4px, -5px, 6px)", null],
+                ["Invalid ry", "rectangle(1px, 2px, 3px, 4px, 5px, -6px)", null]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-arguments-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-arguments-000.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Basic Shape Computed Relative Lengths</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#basic-shapes-from-svg-syntax">
+        <meta name="assert" content="A basic basic shape can contain all unit types">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            // relative units: em, ex, ch, rem, vw, vh, vmin, vmax
+            // fixed units: cm, mm, in, px, pt, pc
+            // percentage unit: %
+            // zero length: 0
+            generate_tests(test_inline_style, [
+                ["0-valued", "rectangle(0, 0, 0, 0)", "rectangle(0px, 0px, 0px, 0px)"],
+                ["Font relative units", "rectangle(1em, 2ex, 3ch, 4rem)"],
+                ["View relative units", "rectangle(1vw, 2vh, 3vmin, 4vmax)"],
+                ["Fixed units", "rectangle(1cm, 2mm, 3in, 4px, 5pt, 6pc)"],
+                ["Percentage units", "rectangle(1%, 2%, 3%, 4%, 5%, 6%)"],
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-arguments-001.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-arguments-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Shape Inline Style Number Values</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#basic-shapes-from-svg-syntax">
+        <meta name="assert" content="The basic shape can contain all valid number formats">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            // number forms: d, +d, -d, .d, +.d, -.d, d.d, +d.d, -d.d
+            generate_tests(test_inline_style, [
+                ["Positive number variations" , "rectangle(1px, +2px, .3px, +.4px, 5.5px, +6.6px)", "rectangle(1px, 2px, 0.3px, 0.4px, 5.5px, 6.6px)"],
+                ["Negative number variations 1", "rectangle(-1px, -.2px, 0px, 0px)", "rectangle(-1px, -0.2px, 0px, 0px)"],
+                ["Negative number variations 2", "rectangle(-1.1px, 0px, 0px, 0px)"]
+            ]);
+        </script>
+    </body>
+</html>

--- a/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-notation-000.html
+++ b/contributors/adobe/submitted/shapes/basic-shapes/shape-outside-shape-notation-000.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Shape Outside Basic Shape Inline Style Functional Notation</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+        <link rel="help" href="http://dev.w3.org/csswg/css-shapes/#basic-shapes-from-svg-syntax">
+        <meta name="assert" content="Basic shapes use functional notation, and may contain optional whitespace">
+        <meta name="flags" content="DOM">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="resources/parsing-utils.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+            generate_tests(test_inline_style, [
+                ["No whitespace" , "rectangle(1px,2px,3px,4px)", "rectangle(1px, 2px, 3px, 4px)"],
+                ["Extra whitespace", "rectangle(  1px,\
+                    2px,  3px,    4px)", "rectangle(1px, 2px, 3px, 4px)"],
+                ["Invalid leading whitespace", "rectangle (1px, 2px, 3px, 4px)", null],
+                ["No commas", "rectangle(1px 2px 3px 4px)", null]
+            ]);
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Moving adobe-webplatform/csswg-test#1 over as a pull request here. I have removed a couple computed style value tests, as the exact format is not specified for some edge cases. The history has also been flattened.
