### PR TITLE
Tests for nav-left/-right/-up/-down CSS 3 UI properties

### DIFF
--- a/contributors/samsung/submitted/css3-ui/nav-down-001.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - property inheritance for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-down' property value is not inherited for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-down: #finish;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="" id="finish">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-002.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'auto' value for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'auto' value is implemented for 'nav-down'.">
+<style type="text/css">
+    #start {
+        nav-down: #finish;
+        nav-down: auto;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="start">START</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="" id="finish">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-003.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - ID value for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the ID value is implemented for 'nav-down'.">
+<style type="text/css">
+    #parent {
+        nav-down: #finish;
+    }
+
+    #intermediate {
+        nav-down: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="" id="intermediate">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-004.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-004.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - input elements for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-down' works for input elements.">
+<style type="text/css">
+    #parent {
+        nav-down: #finish;
+    }
+
+    #intermediate {
+        nav-down: #end;
+    }
+
+   input {
+     display: block;
+   }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" text field.</p>
+
+    <div id="parent">
+      <input value="ignore"/>
+      <input value="START"/>
+      <input value="ignore" id="intermediate"/>
+      <input value="ignore"/>
+    </div>
+
+    <div>
+      <input value="ignore"/>
+      <input value="FINISH" id="end"/>
+      <input value="ignore"/>
+      <input value="ignore"/>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-005.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-005.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in the writing direction for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-down' works for elements floating to the left.">
+<style type="text/css">
+    div > a {
+        float: left;
+        margin-left: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: left;
+    }
+
+    #parent {
+        nav-down: #finish;
+    }
+
+    #intermediate {
+        nav-down: #end;
+    }
+
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="">START</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="intermediate">ignore 2</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-006.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-006.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in opposite to the writing direction for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-down' works for elements floating to the right.">
+<style type="text/css">
+    div > a {
+        float: right;
+        margin-left: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: right;
+    }
+
+    #parent {
+        nav-down: #finish;
+    }
+
+    #intermediate {
+        nav-down: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="">ignore 2</a>
+      <a href="">START</a>
+      <a href="">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="end">FINISH</a>
+      <a href="" id="intermediate">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-007.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-007.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non existing ID for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-down' is ignored if the ID does not exist.">
+<style type="text/css">
+    #parent {
+        nav-down: #error;
+    }
+
+    #intermediate {
+        nav-down: #foobar;
+    }
+
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">START</a></p>
+      <p><a href="" id="intermediate">ignore</a></p>
+      <p><a href="" id="end">FINISH</a>
+      <p><a href="">ignore</a>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a>
+      <p><a href="">ignore</a>
+      <p><a href="" id="error">ignore</a>
+      <p><a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-008.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-008.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - currently focused element for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus doesn't change when navigating to the currently focused element for 'nav-down'.">
+<style>
+    #start {
+        nav-down: #start;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if the "START" element remains focused when navigating down.</p>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="start">START</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-009.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-009.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'current' target frame for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'current' frame value is respected for 'nav-down'.">
+<style>
+    #start {
+        nav-down: #finish current;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <div>
+        <p><a href="" id="finish">FINISH</a></p>
+        <iframe src="support/nav-down-009-frame.html"></iframe>
+        <p><a href="" id="start">START</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-010.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-010.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'root' target frame for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'root' frame value is respected for 'nav-down'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">FINISH</a></p>
+
+    <iframe src="support/nav-down-010-frame.html"></iframe>
+
+    <p><a href="">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-011.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-011.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - named target frame for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="contributor" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named target frame value is respected for 'nav-down'.">
+<style>
+    #start {
+        nav-down: #finish "frame";
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
+
+    <p>
+      <a href="" id="start">START</a>
+    </p>
+    <p>
+      <a href="" id="finish">ignore</a>
+    </p>
+
+    <iframe src="support/nav-down-011-frame.html" name="frame"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-012.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non-existing target frame for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a non-existing target frame value is treated as 'current' for 'nav-down'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">ignore</a></p>
+
+    <iframe src="support/nav-down-012-frame.html"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-013.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-013.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - sibling target frame for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named frame value also works for sibling frames for 'nav-down'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
+
+    <iframe src="support/nav-down-013-frame.html"></iframe>
+    <iframe src="support/nav-down-011-frame.html" name="sibling"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-014.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-014.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - missing target element for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus does not change to a different frame if the identifier is missing from the target frame for 'nav-down'.">
+<style>
+    #start {
+        nav-down: #finish current;
+    }
+    #intermediate {
+        nav-down: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="start">START</a></p>
+    <p><a href="" id="intermediate">ignore</a></p>
+    <p><a href="">ignore</a></p>
+
+    <iframe src="support/nav-down-009-frame.html"></iframe>
+
+    <p><a href="" id="end">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-015.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-015.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'inherit' value for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'inherit' value is implemented for 'nav-down'.">
+<style type="text/css">
+    #parent {
+        nav-down: #end;
+    }
+
+    #intermediateParent, #intermediate {
+        nav-down: inherit;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p id="intermediateParent"><a href="" id="intermediate">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-down-016.html
+++ b/contributors/samsung/submitted/css3-ui/nav-down-016.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - disabled elements are not navigated for 'nav-down'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that disabled elements are not navigated for 'nav-down'.">
+<style type="text/css">
+    #start {
+        nav-down: #intermediate;
+    }
+    input {
+      display: block;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating down moves the focus to the "FINISH" text field and not the disabled "ignore" one.</p>
+
+    <div id="parent">
+      <input value="START"/>
+      <input value="ignore" disabled="disabled" id="intermediate"/>
+      <input value="FINISH"/>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-001.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - property inheritance for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-left' property value is not inherited for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-left: #finish;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">START</a>
+      <a href="" id="finish">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-002.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'auto' value for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'auto' value is implemented for 'nav-left'.">
+<style type="text/css">
+    #start {
+        nav-left: #finish;
+        nav-left: auto;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="" id="start">START</a>
+      <a href="" id="finish">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-003.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - ID value for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the ID value is implemented for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-left: #finish;
+    }
+
+    #intermediate {
+        nav-left: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">START</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-004.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-004.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - input elements for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-left' works for input elements.">
+<style type="text/css">
+    #parent {
+        nav-left: #finish;
+    }
+
+    #intermediate {
+        nav-left: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" text field.</p>
+
+    <div id="parent">
+      <input value="ignore"/>
+      <input value="ignore" id="intermediate"/>
+      <input value="START"/>
+      <input value="ignore"/>
+    </div>
+
+    <div>
+      <input value="ignore"/>
+      <input value="FINISH" id="end"/>
+      <input value="ignore"/>
+      <input value="ignore"/>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-005.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-005.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in the writing direction for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-left' works for elements floating to the left.">
+<style type="text/css">
+    div > a {
+        float: left;
+        margin-left: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: left;
+    }
+
+    #parent {
+        nav-left: #finish;
+    }
+
+    #intermediate {
+        nav-left: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="" id="intermediate">ignore 2</a>
+      <a href="">START</a>
+      <a href="">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-006.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-006.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in opposite to the writing direction for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-left' works for elements floating to the right.">
+<style type="text/css">
+    div > a {
+        float: right;
+        margin-left: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: right;
+    }
+
+    #parent {
+        nav-left: #finish;
+    }
+
+    #intermediate {
+        nav-left: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="">ignore 2</a>
+      <a href="">START</a>
+      <a href="" id="intermediate">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-007.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-007.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non existing ID for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-left' is ignored if the ID does not exist.">
+<style type="text/css">
+    #parent {
+        nav-left: #error;
+    }
+
+    #intermediate {
+        nav-left: #foobar;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="" id="end">FINISH</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">START</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+      <a href="" id="error">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-008.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-008.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - currently focused element for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus doesn't change when navigating to the currently focused element for 'nav-left'.">
+<style>
+    #start {
+        nav-left: #start;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if the "START" element remains focused when navigating left.</p>
+
+    <div><a href="">ignore</a> <a href="" id="start">START</a> <a href="">ignore</a></div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-009.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-009.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'current' target frame for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'current' frame value is respected for 'nav-left'.">
+<style>
+    #start {
+        nav-left: #finish current;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <div>
+        <a href="" id="finish">FINISH</a>
+        <iframe src="support/nav-left-009-frame.html"></iframe>
+        <a href="" id="start">START</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-010.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-010.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'root' target frame for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'root' frame value is respected for 'nav-left'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">FINISH</a></p>
+
+    <iframe src="support/nav-left-010-frame.html"></iframe>
+
+    <p><a href="">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-011.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-011.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - named target frame for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="contributor" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named target frame value is respected for 'nav-left'.">
+<style>
+    #start {
+        nav-left: #finish "frame";
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <p>
+      <a href="" id="finish">ignore</a>
+      <a href="" id="start">START</a>
+    </p>
+
+    <iframe src="support/nav-left-011-frame.html" name="frame"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-012.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non-existing target frame for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a non-existing target frame value is treated as 'current' for 'nav-left'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">ignore</a></p>
+
+    <iframe src="support/nav-left-012-frame.html"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-013.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-013.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - sibling target frame for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named frame value also works for sibling frames for 'nav-left'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left once moves the focus to the "FINISH" link.</p>
+
+    <iframe src="support/nav-left-013-frame.html"></iframe>
+    <iframe src="support/nav-left-011-frame.html" name="sibling"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-014.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-014.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - missing target element for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus does not change to a different frame if the identifier is missing from the target frame for 'nav-left'.">
+<style>
+    #start {
+        nav-left: #finish current;
+    }
+    #intermediate {
+        nav-left: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <p><a href="">ignore</a> <a href="" id="intermediate">ignore</a> <a href="" id="start">START</a></p>
+
+    <iframe src="support/nav-left-009-frame.html"></iframe>
+
+    <p><a href="" id="end">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-015.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-015.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'inherit' value for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'inherit' value is implemented for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-left: #end;
+    }
+
+    #intermediate {
+        nav-left: inherit;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">START</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-left-016.html
+++ b/contributors/samsung/submitted/css3-ui/nav-left-016.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - disabled elements are not navigated for 'nav-left'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that disabled elements are not navigated for 'nav-left'.">
+<style type="text/css">
+    #start {
+        nav-left: #intermediate;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating left moves the focus to the "FINISH" text field and not the disabled "ignore" one.</p>
+
+    <div id="parent">
+      <input value="FINISH"/>
+      <input value="ignore" disabled="disabled" id="intermediate"/>
+      <input value="START"/>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-001.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - property inheritance for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-right' property value is not inherited for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-right: #finish;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="">START</a>
+      <a href="" id="end">FINISH</a>
+      <a href="" id="finish">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-002.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'auto' value for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'auto' value is implemented for 'nav-right'.">
+<style type="text/css">
+    #start {
+        nav-right: #finish;
+        nav-right: auto;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="" id="start">START</a>
+      <a href="" id="end">FINISH</a>
+      <a href="" id="finish">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-003.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - ID value for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the ID value is implemented for 'nav-right'.">
+<style type="text/css">
+    #parent {
+        nav-right: #finish;
+    }
+
+    #intermediate {
+        nav-right: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="">START</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-004.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-004.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - input elements for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-right' works for input elements.">
+<style type="text/css">
+    #parent {
+        nav-right: #finish;
+    }
+
+    #intermediate {
+        nav-right: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" text field.</p>
+
+    <div id="parent">
+      <input value="ignore"/>
+      <input value="START"/>
+      <input value="ignore" id="intermediate"/>
+      <input value="ignore"/>
+    </div>
+
+    <div>
+      <input value="ignore"/>
+      <input value="FINISH" id="end"/>
+      <input value="ignore"/>
+      <input value="ignore"/>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-005.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-005.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in the writing direction for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-right' works for elements floating to the left.">
+<style type="text/css">
+    div > a {
+        float: left;
+        margin-right: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: left;
+    }
+
+    #parent {
+        nav-right: #finish;
+    }
+
+    #intermediate {
+        nav-right: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="">START</a>
+      <a href="" id="intermediate">ignore 2</a>
+      <a href="">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-006.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-006.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in opposite to the writing direction for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-right' works for elements floating to the right.">
+<style type="text/css">
+    div > a {
+        float: right;
+        margin-right: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: right;
+    }
+
+    #parent {
+        nav-right: #finish;
+    }
+
+    #intermediate {
+        nav-right: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="" id="intermediate">ignore 2</a>
+      <a href="">START</a>
+      <a href="">ignore 3</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-007.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-007.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non existing ID for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-right' is ignored if the ID does not exist.">
+<style type="text/css">
+    #parent {
+        nav-right: #error;
+    }
+
+    #intermediate {
+        nav-right: #foobar;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">START</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+      <a href="" id="error">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-008.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-008.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - currently focused element for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus doesn't change when navigating to the currently focused element for 'nav-right'.">
+<style>
+    #start {
+        nav-right: #start;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if the "START" element remains focused when navigating right.</p>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="" id="start">START</a>
+      <a href="">ignore</a>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-009.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-009.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'current' target frame for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'current' frame value is respected for 'nav-right'.">
+<style>
+    #start {
+        nav-right: #finish current;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <div>
+        <a href="" id="start">START</a>
+        <iframe src="support/nav-right-009-frame.html"></iframe>
+        <a href="" id="finish">FINISH</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-010.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-010.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'root' target frame for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'root' frame value is respected for 'nav-right'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">FINISH</a></p>
+
+    <iframe src="support/nav-right-010-frame.html"></iframe>
+
+    <p><a href="">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-011.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-011.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - named target frame for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="contributor" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named target frame value is respected for 'nav-right'.">
+<style>
+    #start {
+        nav-right: #finish "frame";
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <p>
+      <a href="" id="start">START</a>
+      <a href="" id="finish">ignore</a>
+    </p>
+
+    <iframe src="support/nav-right-011-frame.html" name="frame"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-012.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non-existing target frame for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a non-existing target frame value is treated as 'current' for 'nav-right'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">ignore</a></p>
+
+    <iframe src="support/nav-right-012-frame.html"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-013.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-013.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - sibling target frame for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named frame value also works for sibling frames for 'nav-right'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right once moves the focus to the "FINISH" link.</p>
+
+    <iframe src="support/nav-right-011-frame.html" name="sibling"></iframe>
+    <iframe src="support/nav-right-013-frame.html"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-014.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-014.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - missing target element for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus does not change to a different frame if the identifier is missing from the target frame for 'nav-right'.">
+<style>
+    #start {
+        nav-right: #finish current;
+    }
+    #intermediate {
+        nav-right: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <p>
+      <a href="" id="start">START</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">ignore</a>
+    </p>
+
+    <iframe src="support/nav-right-009-frame.html"></iframe>
+
+    <p><a href="" id="end">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-015.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-015.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'inherit' value for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'inherit' value is implemented for 'nav-right'.">
+<style type="text/css">
+    #parent {
+        nav-right: #end;
+    }
+
+    #intermediate {
+        nav-right: inherit;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore</a>
+      <a href="">START</a>
+      <a href="" id="intermediate">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+    <div>
+      <a href="">ignore</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore</a>
+      <a href="">ignore</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-right-016.html
+++ b/contributors/samsung/submitted/css3-ui/nav-right-016.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - disabled elements are not navigated for 'nav-right'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that disabled elements are not navigated for 'nav-right'.">
+<style type="text/css">
+    #start {
+        nav-right: #intermediate;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating right moves the focus to the "FINISH" text field and not the disabled "ignore" one.</p>
+
+    <div id="parent">
+      <input value="START"/>
+      <input value="ignore" disabled="disabled" id="intermediate"/>
+      <input value="FINISH"/>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-001.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - property inheritance for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-up' property value is not inherited for 'nav-left'.">
+<style type="text/css">
+    #parent {
+        nav-up: #finish;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="" id="finish">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-002.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'auto' value for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'auto' value is implemented for 'nav-up'.">
+<style type="text/css">
+    #start {
+        nav-up: #finish;
+        nav-up: auto;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="" id="start">START</a></p>
+      <p><a href="" id="finish">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-003.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - ID value for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the ID value is implemented for 'nav-up'.">
+<style type="text/css">
+    #parent {
+        nav-up: #finish;
+    }
+
+    #intermediate {
+        nav-up: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="intermediate">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-004.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-004.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - input elements for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-up' works for input elements.">
+<style type="text/css">
+    #parent {
+        nav-up: #finish;
+    }
+
+    #intermediate {
+        nav-up: #end;
+    }
+
+    input {
+      display: block;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" text field.</p>
+
+    <div id="parent">
+      <input value="ignore"/>
+      <input value="ignore" id="intermediate"/>
+      <input value="START"/>
+      <input value="ignore"/>
+    </div>
+
+    <div>
+      <input value="ignore"/>
+      <input value="FINISH" id="end"/>
+      <input value="ignore"/>
+      <input value="ignore"/>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-005.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-005.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in the writing direction for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-up' works for elements floating to the left.">
+<style type="text/css">
+    div > a {
+        float: up;
+        margin-up: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: up;
+    }
+
+    #parent {
+        nav-up: #finish;
+    }
+
+    #intermediate {
+        nav-up: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore 1</a></p>
+      <p><a href="" id="intermediate">ignore 2</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="">ignore 3</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore 4</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">ignore 5</a></p>
+      <p><a href="">ignore 6</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-006.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-006.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - elements floating in opposite to the writing direction for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that 'nav-up' works for elements floating to the right.">
+<style type="text/css">
+    div > a {
+        float: right;
+        margin-up: 1em;
+        margin-right: 1em;
+    }
+
+    div {
+        clear: right;
+    }
+
+    #parent {
+        nav-up: #finish;
+    }
+
+    #intermediate {
+        nav-up: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <a href="">ignore 1</a>
+      <a href="" id="intermediate">ignore 3</a>
+      <a href="" id="end">FINISH</a>
+      <a href="">ignore 2</a>
+    </div>
+
+    <div>
+      <a href="">ignore 4</a>
+      <a href="">START</a>
+      <a href="">ignore 5</a>
+      <a href="">ignore 6</a>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-007.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-007.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non existing ID for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'nav-up' is ignored if the ID does not exist.">
+<style type="text/css">
+    #parent {
+        nav-up: #error;
+    }
+
+    #intermediate {
+        nav-up: #foobar;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="" id="intermediate">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="error">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-008.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-008.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - currently focused element for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus doesn't change when navigating to the currently focused element for 'nav-up'.">
+<style>
+    #start {
+        nav-up: #start;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if the "START" element remains focused when navigating up.</p>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="start">START</a></p>
+      <p><a href="">ignore</a></div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-009.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-009.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'current' target frame for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'current' frame value is respected for 'nav-up'.">
+<style>
+    #start {
+        nav-up: #finish current;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <div>
+        <p><a href="" id="finish">FINISH</a></p>
+        <iframe src="support/nav-up-009-frame.html"></iframe>
+        <p><a href="" id="start">START</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-010.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-010.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'root' target frame for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'root' frame value is respected for 'nav-up'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">FINISH</a></p>
+
+    <iframe src="support/nav-up-010-frame.html"></iframe>
+
+    <p><a href="">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-011.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-011.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - named target frame for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="contributor" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named target frame value is respected for 'nav-up'.">
+<style>
+    #start {
+        nav-up: #finish "frame";
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">ignore</a></p>
+    <p><a href="" id="start">START</a></p>
+
+    <iframe src="support/nav-up-011-frame.html" name="frame"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-012.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - non-existing target frame for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a non-existing target frame value is treated as 'current' for 'nav-up'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <p><a href="" id="finish">ignore</a></p>
+
+    <iframe src="support/nav-up-012-frame.html"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-013.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-013.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - sibling target frame for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that a named frame value also works for sibling frames for 'nav-up'.">
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+
+    <iframe src="support/nav-up-013-frame.html"></iframe>
+    <iframe src="support/nav-up-011-frame.html" name="sibling"></iframe>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-014.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-014.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - missing target element for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that focus does not change to a different frame if the identifier is missing from the target frame for 'nav-up'.">
+<style>
+    #start {
+        nav-up: #finish current;
+    }
+    #intermediate {
+        nav-up: #end;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <p><a href="">ignore</a></p>
+    <p><a href="" id="intermediate">ignore</a></p>
+    <p><a href="" id="start">START</a></p>
+
+    <iframe src="support/nav-up-009-frame.html"></iframe>
+
+    <p><a href="" id="end">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-015.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-015.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - 'inherit' value for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that the 'inherit' value is implemented for 'nav-up'.">
+<style type="text/css">
+    #parent {
+        nav-up: #end;
+    }
+
+    #intermediateParent, #intermediate {
+        nav-up: inherit;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up twice moves the focus to the "FINISH" link.</p>
+
+    <div id="parent">
+      <p><a href="">ignore</a></p>
+      <p id="intermediateParent"><a href="" id="intermediate">ignore</a></p>
+      <p><a href="">START</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+    <div>
+      <p><a href="">ignore</a></p>
+      <p><a href="" id="end">FINISH</a></p>
+      <p><a href="">ignore</a></p>
+      <p><a href="">ignore</a></p>
+    </div>
+
+</body>

--- a/contributors/samsung/submitted/css3-ui/nav-up-016.html
+++ b/contributors/samsung/submitted/css3-ui/nav-up-016.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - disabled elements are not navigated for 'nav-up'</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that disabled elements are not navigated for 'nav-up'.">
+<style type="text/css">
+    #start {
+        nav-up: #intermediate;
+    }
+
+    input {
+      display: block;
+    }
+</style>
+<body>
+    <p>First, use directional navigation to navigate the focus to the "START" text field below.</p>
+    <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+         In the SmartTV emulator, use the keypad in the GUI. -->
+    <p>Test passes if navigating up moves the focus to the "FINISH" text field and not the disabled "ignore" one.</p>
+
+    <div id="parent">
+      <input value="FINISH"/>
+      <input value="ignore" disabled="disabled" id="intermediate"/>
+      <input value="START"/>
+    </div>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-down-009-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-down-009-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with #finish to ignore</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-down-010-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-down-010-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-down: #finish root }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-down: #finish root;
+    }
+</style>
+<body>
+    <p><a href="" id="start">START</a></p>
+    <p><a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-down-011-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-down-011-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with target #finish</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-down-012-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-down-012-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-down: #finish "frame" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-down: #finish frame;
+    }
+</style>
+<body>
+    <p><a href="" id="start">START</a> <a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-down-013-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-down-013-frame.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-down: #finish "sibling" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-down: #finish "sibling";
+    }
+</style>
+<body>
+    <p>
+      <a href="" id="start">START</a>
+    </p>
+    <p>
+      <a href="" id="finish">ignore</a>
+    </p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-left-009-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-left-009-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with #finish to ignore</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-left-010-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-left-010-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-left: #finish root }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-left: #finish root;
+    }
+</style>
+<body>
+    <p><a href="" id="start">START</a> <a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-left-011-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-left-011-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with target #finish</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-left-012-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-left-012-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-left: #finish "frame" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-left: #finish frame;
+    }
+</style>
+<body>
+    <p><a href="" id="start">START</a> <a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-left-013-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-left-013-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-left: #finish "sibling" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-left: #finish "sibling";
+    }
+</style>
+<body>
+    <p><a href="" id="finish">ignore</a> <a href="" id="start">START</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-right-009-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-right-009-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with #finish to ignore</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-right-010-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-right-010-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-right: #finish root }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-right: #finish root;
+    }
+</style>
+<body>
+    <p><a href="" id="finish">ignore</a> <a href="" id="start">START</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-right-011-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-right-011-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with target #finish</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-right-012-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-right-012-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-right: #finish "frame" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-right: #finish frame;
+    }
+</style>
+<body>
+    <p><a href="" id="finish">FINISH</a> <a href="" id="start">START</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-right-013-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-right-013-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-right: #finish "sibling" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-right: #finish "sibling";
+    }
+</style>
+<body>
+    <p><a href="" id="finish">ignore</a> <a href="" id="start">START</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-up-009-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-up-009-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with #finish to ignore</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-up-010-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-up-010-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-up: #finish root }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-up: #finish root;
+    }
+</style>
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+    <p><a href="" id="start">START</a> </p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-up-011-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-up-011-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with target #finish</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<body>
+    <p><a href="" id="finish">FINISH</a></p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-up-012-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-up-012-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-up: #finish "frame" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-up: #finish frame;
+    }
+</style>
+<body>
+    <p><a href="" id="finish">FINISH</a></p>
+    <p><a href="" id="start">START</a> </p>
+</body>

--- a/contributors/samsung/submitted/css3-ui/support/nav-up-013-frame.html
+++ b/contributors/samsung/submitted/css3-ui/support/nav-up-013-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - frame with: #start { nav-up: #finish "sibling" }</title>
+<link rel="author" title="Jorrit Vermeiren" href="mailto:jorritv@opera.com">
+<link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
+<style>
+    #start {
+        nav-up: #finish "sibling";
+    }
+</style>
+<body>
+    <p><a href="" id="finish">ignore</a></p>
+    <p><a href="" id="start">START</a></p>
+</body>


### PR DESCRIPTION
New and complete set of 64 tests for CSS 3 UI nav-left, nav-right, nav-up and nav-down properties. Adapted and extended from original tests submitted by Opera. I believe all normative assertions from the spec are tested. All tests passed by Opera TV Emulator and build of Chomium submitted by Samsung to the CSS WG. Reviews requested please :-)

Daniel Glazman
