### PR TITLE
Tests for GCPM Running Heads and Leaders

### DIFF
--- a/leader-001.xht
+++ b/leader-001.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: Dotted leader</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#leaders">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a basic dotted leader is implemented">
+<style>
+ 
+span.cn::after { content: leader(dotted); }
+ 
+</style>
+</head>
+<body>
+
+<p>Test passes if there's a dotted leader between "Chapter One" and "1"</p>
+
+<ol>
+<li>
+<span class="cn">Chapter One</span> <span class="folio">1</span>
+</li>
+<!-- 
+<li>
+Chapter Two <span class="folio">137</span>
+</li>
+ -->
+</ol>
+
+
+
+</body>
+</html>

--- a/leader-002.xht
+++ b/leader-002.xht
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: custom leaders</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#dotted-leader">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a custom character leader is implemented">
+<style>
+
+p.run-in { display: run-in; }
+
+p.source-rw::before { 
+content: leader('~ ');
+}
+
+ 
+</style>
+</head>
+<body>
+
+<p>Test passes if there are ~ characters between the end of the text and Ahab’s name</p>
+
+<blockquote>
+
+<p class="run-in">“Towards thee I roll, thou all-destroying but unconquering whale; to the last I grapple with thee; from hell’s heart I stab at thee; for hate’s sake I spit my last breath at thee. Sink all coffins and all hearses to one common pool! and since neither can be mine, let me then tow to pieces, while still chasing thee, though tied to thee, thou damned whale! THUS, I give up the spear!”</p>
+
+<p class="source-rw">Ahab</p>
+</blockquote>
+
+
+
+</body>
+</html>

--- a/leader-003.xht
+++ b/leader-003.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: Dotted leader</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#solid-leader">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a basic solid leader is implemented">
+<style>
+ 
+span.cn::after { content: leader(solid); }
+ 
+</style>
+</head>
+<body>
+
+<p>Test passes if there's a continuous row of underscores between "Chapter One" and "1"</p>
+
+<ol>
+<li>
+<span class="cn">Chapter One</span> <span class="folio">1</span>
+</li>
+<!-- 
+<li>
+Chapter Two <span class="folio">137</span>
+</li>
+ -->
+</ol>
+
+
+
+</body>
+</html>

--- a/string-set-001.xht
+++ b/string-set-001.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set with string</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a named string can be set to a string value.">
+<style type="text/css">
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title 'hello, world'; 
+ }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “hello, world” appears the running head at the top of the page.</p>
+</body>
+</html>

--- a/string-set-002.xht
+++ b/string-set-002.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM String-set with content()</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the text value of an element, using the default content() syntax">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title content(); 
+ }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/string-set-003.xht
+++ b/string-set-003.xht
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM String-set with content(text)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the text value of an element, using the explicit content(text) syntax">
+<style type="text/css">
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title content(text); 
+ }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if the text “Chapter Title” appears in the running head at the top of the page.</p>
+<!--AH errors out with content(text) rather than content()-->
+</body>
+</html>

--- a/string-set-004.xht
+++ b/string-set-004.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM String-set with content(first-letter)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the first letter of the text value of an element">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title content(first-letter); 
+ }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “C” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/string-set-005.xht
+++ b/string-set-005.xht
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM String-set with counter(page)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a named string can be set to the value of the page counter">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title counter(page); 
+ }
+</style>
+</head>
+<body>
+<p>Test passes if “1” appears in a blue box (the running head) at the top of the page.</p>
+</body>
+</html>

--- a/string-set-006.xht
+++ b/string-set-006.xht
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set with content(before)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a named string can be set to the content of the before pseudo-element">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title content(before); 
+ }
+ 
+ h1::before {
+ content: 'before-';
+ }
+ 
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “before-” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/string-set-007.xht
+++ b/string-set-007.xht
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set with content(after)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a named string can be set to the content of the after pseudo-element">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+   string-set: title content(after); 
+ }
+ 
+ h1::after {
+ content: '-after';
+ }
+ 
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “-after” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/string-set-008.xht
+++ b/string-set-008.xht
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set with multiple assignments</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that several named string can be set on a single element">
+<style>
+  @page {
+   @top-center {
+   content: string(center); 
+   }
+   @top-left {
+   content: string(left); 
+   }
+   @top-right {content: 
+   string(right); 
+   }
+  }
+ 
+ h1 {
+   string-set: left content(), right content(), center content(first-letter); 
+ }
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in both the left and right running heads, and “C” appears in the center running head.</p>
+</body>
+</html>

--- a/string-set-009.xht
+++ b/string-set-009.xht
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set with page and pages counters</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the page and pages counters">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+
+  }
+ 
+ h1 {
+ string-set: title counter(page) ' of ' counter(pages); 
+
+ }
+ 
+
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “1 of 1” appears in the running head.</p>
+</body>
+</html>

--- a/string-set-010.xht
+++ b/string-set-010.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set on element with display: none</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED--><meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the value of an element even if display is set to none">
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+
+  }
+ 
+ h1 {
+ string-set: title content(); 
+display: none;
+ }
+ 
+
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in the running head.</p>
+</body>
+</html>

--- a/string-set-011.xht
+++ b/string-set-011.xht
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set on element with display: none</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the value of an element even if display is set to none">
+<!--
+Note this test exposes a known bug in PrinceXML 9.0 rev 2 (and all previous versions)
+-->
+<style>
+  @page {
+   @top-center {
+   content: string(title); 
+   }
+  }
+ 
+ h1 {
+ string-set: title content(); 
+ display: none;
+ }
+ 
+#d2 { page-break-before: always; }
+ 
+</style>
+</head>
+<body>
+<h1>Chapter One Title</h1>
+<p>Note: test has two pages</p>
+<p>Test passes if:</p>
+<ol>
+<li>
+“Chapter One Title” appears in the running head on page one.
+</li>
+<li>
+“Chapter Two Title” appears in the running head on page two.
+</li>
+</ol>
+
+<div id="d2">
+<h1>Chapter Two Title</h1>
+<p>Second Page</p>
+</div>
+</body>
+</html>

--- a/string-set-012.xht
+++ b/string-set-012.xht
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: GCPM string-set to attribute value</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-set">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that a string can be set to the value of an attribute ">
+
+<style>
+  @page {
+   @top-center {
+   content: string(header); 
+   }
+  }
+ 
+ h1 {
+ string-set: header attr(title); 
+ }
+ 
+ 
+</style>
+</head>
+<body>
+<h1 title="Hello, World">Chapter Title</h1>
+<p>Test passes if running head text reads “Hello, World”.
+
+
+
+
+</body>
+</html>

--- a/using-strings-001.xht
+++ b/using-strings-001.xht
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: using 'first' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-first">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that the default value of the string property is first, so that the first instance of a named string on the page is used.">
+<style>
+  @page {
+   @top-center {
+   content: string(section); 
+   }
+  }
+ 
+ h2 {
+ string-set: section content();
+
+ }
+ 
+
+ 
+</style>
+</head>
+<body>
+<p>Test passes if “Section One” is in the running head at the top of the page.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/using-strings-002.xht
+++ b/using-strings-002.xht
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: using the 'last' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-last">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that the last instance of a named string is used, when the 'last' property is applied to the string.">
+<style>
+  @page {
+   @top-center {
+   content: string(section, last); 
+   }
+  }
+ 
+ h2 {
+ string-set: section content();
+ }
+ 
+</style>
+</head>
+<body>
+<p>Test passes if the text "Section Six" is in the running head at the top of the page.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/using-strings-003.xht
+++ b/using-strings-003.xht
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: using 'start' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-start">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that the string set at the beginning of a page is used when the start property is applied">
+<style>
+  @page {
+   @top-center {
+   content: string(section, start); 
+   }
+  }
+ 
+ h2 {
+ string-set: section content();
+ }
+ 
+ #s2 { page-break-before: always; }
+#s4 { page-break-after: always; }
+ 
+</style>
+</head>
+<body>
+<p>Note: this test has three pages</p>
+<p>Test passes if:</p>
+
+<ol>
+<li>
+On page one, the running head is empty.
+</li>
+<li>
+On page two, the running head is “Section Two”
+</li>
+<li>
+On page three, the running head is “Section Four”
+</li>
+</ol>
+<h2 id="s1">Section One</h2>
+<p id="p1">Bacon ipsum dolor sit amet brisket sunt kielbasa, sed rump fatback shankle. Non exercitation aliquip culpa shankle. Sausage pork kevin, doner meatloaf venison cupidatat. Salami frankfurter spare ribs kielbasa culpa commodo incididunt. Tri-tip pork belly pig ut ground round est, turkey drumstick nisi quis. Occaecat nisi tempor cupidatat, ground round exercitation in turducken. Filet mignon cow pork bacon tri-tip fugiat mollit kevin et.</p>
+<h2 id="s2">Section Two</h2>
+<p>
+Fatback excepteur ex ut shank do ham. Sausage sirloin turducken velit ex spare ribs quis. Quis in turkey, labore sirloin fatback exercitation proident. In rump reprehenderit voluptate aute ribeye excepteur pig venison. Culpa laboris in nostrud, kevin leberkas non tri-tip commodo qui tenderloin. Id non short ribs elit, ut excepteur cow venison duis do.
+</p>
+<h2 id="s3">Section Three</h2>
+<p>
+Ullamco strip steak aliqua bacon ut sirloin turkey pork chop, ball tip jowl. Commodo pancetta prosciutto, meatloaf eiusmod aliquip chicken occaecat pig. Ut in pork, short ribs chuck t-bone kielbasa irure jowl occaecat cupidatat nostrud officia. Dolore ball tip cupidatat labore esse ut, magna leberkas irure kevin nostrud aute eu pariatur eiusmod. Nostrud pancetta labore, eu est mollit jerky ham hock. Shoulder aliquip dolore eu corned beef strip steak commodo.
+</p>
+<h2 id="s4">Section Four</h2>
+<p>
+Frankfurter prosciutto fatback beef ribs brisket, flank consectetur proident cupidatat ham hock enim pig eu bresaola. Qui ball tip consequat short loin salami. Tri-tip tempor et, adipisicing commodo ground round ball tip andouille doner. Short loin officia ea ground round shank.
+</p>
+<h2 id="s5">Section Five</h2>
+<p>Biltong in capicola commodo tenderloin irure, labore drumstick aute tri-tip veniam. Labore dolore doner ex, meatloaf tempor meatball id flank do turkey. Pig culpa ut prosciutto rump. Tongue chicken qui andouille, pork loin pork chop salami ut. Eu ea qui dolore pork chop ground round.</p>
+<h2 id="s6">Section Six</h2>
+<p>Ham hock jowl filet mignon pastrami beef turducken. Brisket pork chop pork loin drumstick capicola ground round shankle andouille leberkas tenderloin turducken chuck t-bone kevin turkey. Turkey brisket shank, cow pork belly strip steak bresaola chicken short ribs biltong. Kevin jowl meatloaf capicola t-bone ham brisket leberkas. Pork strip steak drumstick jerky, flank shankle capicola turkey spare ribs.</p>
+</body>
+</html>

--- a/using-strings-004.xht
+++ b/using-strings-004.xht
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: using 'first-except' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-first-except">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that if string is set to first-except, it is omitted on the page where the string is set, but appears on subsequent pages">
+<style>
+  @page {
+   @top-center {
+   content: string(title, first-except);
+   }
+  }
+ 
+ h1 {
+ string-set: title content();
+ }
+ 
+#s2, #s3, #s4 { page-break-before: always; }
+ 
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if the running head is omitted on page one, and is “Chapter Title” on all other pages.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/using-strings-005.xht
+++ b/using-strings-005.xht
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Test: using 'last' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dave.cramer@hbgusa.com">
+<link rel="help" href="http://dev.w3.org/csswg/css-gcpm/#string-last">
+<!--WD of this spec is out of date; referencing the ED-->
+<meta name="flags" content="paged">
+<meta name="assert" content="Test checks that if string is set to last, the last appearance of that element determines the content of the string">
+<style>
+  @page {
+   @top-center {
+   content: string(title, last);
+   }
+  }
+ 
+ h2 {
+ string-set: title content();
+ }
+ 
+#s2, #s4 { page-break-before: always; }
+ 
+</style>
+</head>
+<body>
+<p>Note: test has three pages. Test passes if:</p>
+<ol>
+<li>
+Running head on page one is “Section One”
+</li>
+<li>
+Running head on page two is “Section Three”
+</li>
+<li>
+Running head on page three is “Section Six”
+</li>
+</ol>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>


### PR DESCRIPTION
Manual tests for string(), string-set() and leaders() in GCPM. These tests link to the upcoming Editor's Draft of GCPM, which should be up in a few days. 
