### PR TITLE
Fixed an email address

### DIFF
--- a/test-plans/css3-regions/index.html
+++ b/test-plans/css3-regions/index.html
@@ -15,7 +15,7 @@
           shortName: "css3-regions-test-strategy",
           editors: [
             {
-              name: "Alan Stearns", mailto: "astearns@adobe.com",
+              name: "Alan Stearns", mailto: "stearns@adobe.com",
               company: "Adobe Systems, Inc.", companyURL: "http://www.adobe.com/"
             },
             {


### PR DESCRIPTION
Misspelled the test coordinator's email in the CSS Regions testing strategy.
