### PR TITLE
css-writing-modes-3: test for text-combine-upright on full-width characters

### DIFF
--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-001.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright on full-width characters</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth">
+<link rel="match" href="full-width-ref.html">
+<meta name="assert" content="When two or more full-width characters are combined, they are first converted to non-full-width characters.">
+<style>
+.vertical-lr {
+  writing-mode: vertical-lr;
+}
+
+.tcu-digits2 {
+  text-combine-upright: digits 2;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-lr">
+  <p><span class="tcu-digits2">６月１９日</span></p>
+  <p><span class="tcu-digits2">６月19日</span></p>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-002.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-002.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright on full-width characters</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-css-text-3-20131010/#full-width">
+<link rel="match" href="full-width-ref.html">
+<meta name="assert" content="When two or more full-width characters are combined, they are first converted to non-full-width characters.">
+<style>
+.vertical-lr {
+  writing-mode: vertical-lr;
+}
+
+.tcu-digits2 {
+  text-combine-upright: digits 2;
+}
+
+.tt-fullwidth {
+  text-transform: full-width;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-lr">
+  <p><span class="tcu-digits2 tt-fullwidth">6月19日</span></p>
+  <p><span class="tcu-digits2">６月19日</span></p>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-ref.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes Reference</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<meta name="flags" content="ahem">
+<style>
+.vertical-lr {
+  writing-mode: vertical-lr;
+}
+
+.tcu-digits2 {
+  text-combine-upright: digits 2;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-lr">
+  <p><span class="tcu-digits2">６月19日</span></p>
+  <p><span class="tcu-digits2">６月19日</span></p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth says:

> when the combined text consists of more than one character, then any full-width
> characters must first be converted to their non-full-width equivalents
- full-width-001.html -- it has full-width characters directly input in the doucment.
- full-width-002.html -- it uses `text-transform: full-width` to achieve the effect.
