### PR TITLE
css-writing-modes-3: test for text-combine-upright in horizontal writing modes

### DIFF
--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001-ref.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001-ref.html
@@ -4,14 +4,19 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes Reference</title>
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<style>
+div p {
+  font-size: 50px;
+}
+</style>
 </head>
 <body>
 
-<p>Test passes if the following paragraphs are identical:</p>
+<p>Test passes if the following texts are identical:</p>
 
 <div>
-  <p>平成26年</p>
-  <p>平成26年</p>
+  <p>2014</p>
+  <p>2014</p>
 </div>
 
 </body>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001.html
@@ -8,6 +8,10 @@
 <link rel="match" href="writing-mode-horizontal-001-ref.html">
 <meta name="assert" content="text-combine-upright does not have an effect in horizontal writing modes.">
 <style>
+div p {
+  font-size: 50px;
+}
+
 .horizontal-tb {
   writing-mode: horizontal-tb;
 }
@@ -19,11 +23,11 @@
 </head>
 <body>
 
-<p>Test passes if the following paragraphs are identical:</p>
+<p>Test passes if the following texts are identical:</p>
 
 <div class="horizontal-tb">
-  <p>平成<span class="tcu-all">26</span>年</p>
-  <p>平成26年</p>
+  <p><span class="tcu-all">2014</span></p>
+  <p>2014</p>
 </div>
 
 </body>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-002-ref.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-002-ref.html
@@ -5,6 +5,10 @@
 <title>CSS Writing Modes Reference</title>
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
 <style>
+div p {
+  font-size: 50px;
+}
+
 .direction-rtl {
   direction: rtl;
 }
@@ -12,11 +16,11 @@
 </head>
 <body>
 
-<p>Test passes if the following paragraphs are identical:</p>
+<p>Test passes if the following texts are identical:</p>
 
 <div class="direction-rtl">
-  <p>平成26年</p>
-  <p>平成26年</p>
+  <p>2014</p>
+  <p>2014</p>
 </div>
 
 </body>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-002.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-002.html
@@ -8,6 +8,10 @@
 <link rel="match" href="writing-mode-horizontal-002-ref.html">
 <meta name="assert" content="text-combine-upright does not have an effect in horizontal writing modes.">
 <style>
+div p {
+  font-size: 50px;
+}
+
 .horizontal-tb {
   writing-mode: horizontal-tb;
 }
@@ -23,11 +27,11 @@
 </head>
 <body>
 
-<p>Test passes if the following paragraphs are identical:</p>
+<p>Test passes if the following texts are identical:</p>
 
 <div class="horizontal-tb direction-rtl">
-  <p>平成<span class="tcu-all">26</span>年</p>
-  <p>平成26年</p>
+  <p><span class="tcu-all">2014</span></p>
+  <p>2014</p>
 </div>
 
 </body>


### PR DESCRIPTION
`text-combine-upright` does not have effect in horizontal writing modes.
to check that we just need a simple test and a reference.
