### PR TITLE
Adding basic tests for the CSS.supports API

### DIFF
--- a/css-conditional-3/js/css-supports-conditional-compounds-001.html
+++ b/css-conditional-3/js/css-supports-conditional-compounds-001.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for compound productions</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports allows for combinations of the productions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var conditions = [
+// negation and conjunction
+["NOT ((margin:0) AND (foo:bar))", true],
+["(margin:0) AND (NOT (foo:bar))", true],
+
+// negation and disjunction
+["NOT ((foo:bar) OR (foo:bar))", true],
+["(NOT (foo:bar)) OR (foo:bar)", true],
+
+// conjunction and disjunction
+["((margin:0) AND (foo:bar)) OR (margin:0)", true],
+["((margin:0) OR (foo:bar)) AND (margin:0)", true],
+
+// negation, conjunction and disjunction
+["(NOT ((margin:0) AND (foo:bar))) OR (foo:bar)", true],
+["((margin:0) AND (NOT (foo:bar))) OR (foo:bar)", true],
+
+["(NOT ((foo:bar) OR (foo:bar))) AND (margin:0)", true],
+["((NOT (foo:bar)) OR (foo:bar)) AND (margin:0)", true],
+
+["NOT (((margin:0) AND (foo:bar)) OR (margin:0))", false],
+["NOT (((margin:0) OR (foo:bar)) AND (margin:0))", false]
+];
+
+function buildTestCases(items) {
+    return items.map(function(item) {
+        var condition = item[0];
+        return [condition, CSS.supports(condition), item[1]];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(conditions));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-conjunction-001.html
+++ b/css-conditional-3/js/css-supports-conditional-conjunction-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for conjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports covers basic conjunctions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + ' AND ' + item2[0];
+            cases.push([condition, CSS.supports(condition), item1[1] && item2[1]]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-conjunction-002.html
+++ b/css-conditional-3/js/css-supports-conditional-conjunction-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for conjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports conjunctions require a space around 'and'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + 'AND' + item2[0];
+            cases.push([condition, CSS.supports(condition), false]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-conjunction-003.html
+++ b/css-conditional-3/js/css-supports-conditional-conjunction-003.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for conjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports conjunctions with nested productions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + ' AND ' + item2[0];
+            cases.push([condition, CSS.supports(condition), item1[1] && item2[1]]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(compoundParentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-conjunction-004.html
+++ b/css-conditional-3/js/css-supports-conditional-conjunction-004.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for conjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports multiple conjunctions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var seedConditions = [
+["(margin:0)", true],
+["(foo:bar)", false]
+];
+
+// Generate an array of length filled with string
+function fill(length, string) {
+    return Array.apply(null, Array(length)).map(String.prototype.valueOf, string);
+}
+
+function buildTestCases(items) {
+    var cases = [];
+    for (var i = 2; i < 5; i++) {
+        items.forEach(function(item) {
+            var condition = fill(i, item[0]).join(' AND ');
+            cases.push([condition, CSS.supports(condition), item[1]]);
+        });
+    }
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(seedConditions));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-disjunction-001.html
+++ b/css-conditional-3/js/css-supports-conditional-disjunction-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for disjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports covers basic disjunctions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + ' OR ' + item2[0];
+            cases.push([condition, CSS.supports(condition), item1[1] || item2[1]]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-disjunction-002.html
+++ b/css-conditional-3/js/css-supports-conditional-disjunction-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for disjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports disjunctions require a space around 'or'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + 'OR' + item2[0];
+            cases.push([condition, CSS.supports(condition), false]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-disjunction-003.html
+++ b/css-conditional-3/js/css-supports-conditional-disjunction-003.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for disjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports disjunctions with nested productions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    items.forEach(function(item1) {
+        items.forEach(function(item2) {
+            var condition = item1[0] + ' OR ' + item2[0];
+            cases.push([condition, CSS.supports(condition), item1[1] || item2[1]]);
+        });
+    });
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(compoundParentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-disjunction-004.html
+++ b/css-conditional-3/js/css-supports-conditional-disjunction-004.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for disjunction</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports multiple disjunctions.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var seedConditions = [
+["(margin:0)", true],
+["(foo:bar)", false]
+];
+
+// Generate an array of length filled with string
+function fill(length, string) {
+    return Array.apply(null, Array(length)).map(String.prototype.valueOf, string);
+}
+
+function buildTestCases(items) {
+    var cases = [];
+    for (var i = 2; i < 5; i++) {
+        items.forEach(function(item) {
+            var condition = fill(i, item[0]).join(' OR ');
+            cases.push([condition, CSS.supports(condition), item[1]]);
+        });
+    }
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(seedConditions));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-negation-001.html
+++ b/css-conditional-3/js/css-supports-conditional-negation-001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for negation</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports appropriately negates parentheticals.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    return items.map(function(item) {
+        var condition = 'NOT ' + item[0];
+        return [condition, CSS.supports(condition), !item[1]];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-negation-002.html
+++ b/css-conditional-3/js/css-supports-conditional-negation-002.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for negation</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports negations require at least one space.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    return items.map(function(item) {
+        var condition = 'NOT' + item[0];
+        return [condition, CSS.supports(condition), false];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-negation-003.html
+++ b/css-conditional-3/js/css-supports-conditional-negation-003.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for negation</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports appropriately negates compound parentheticals.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    return items.map(function(item) {
+        var condition = 'NOT ' + item[0];
+        return [condition, CSS.supports(condition), !item[1]];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(compoundParentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-parentheses-001.html
+++ b/css-conditional-3/js/css-supports-conditional-parentheses-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for supports_condition_in_parens</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports appropriately matches the supports_condition_in_parens production with no additional logical operators.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    return items.map(function(item) {
+        return [item[0], CSS.supports(item[0]), item[1]];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-conditional-parentheses-002.html
+++ b/css-conditional-3/js/css-supports-conditional-parentheses-002.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports condition text for supports_condition_in_parens</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports allows nesting of parentheticals with and
+without spaces.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function buildTestCases(items) {
+    var cases = [];
+    cases = cases.concat(items.map(function(item) {
+        var condition = '(' + item[0] +')';
+        return [condition, CSS.supports(condition), item[1]];
+    }));
+    cases = cases.concat(items.map(function(item) {
+        var condition = ' ( ' + item[0] + ' ) ';
+        return [condition, CSS.supports(condition), item[1]];
+    }));
+    return cases;
+}
+
+generate_tests(assert_equals, buildTestCases(parentheticals));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-property-value-001.html
+++ b/css-conditional-3/js/css-supports-property-value-001.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS.supports property value syntax</title>
+<link rel="author" title="Adobe" href="http://html.adobe.com">
+<link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
+<link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-css-interface">
+<meta name="assert" content="CSS.supports accepts a property value pair.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='css-supports-utils.js'></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var tests = [
+
+["margin", "0", true],
+["margin", "1px 1px 1px 1px", true],
+["margin", "0 !important", true],
+["margin", "1", false],
+["foo", "bar", false]
+
+]
+function buildTestCases(items) {
+    return items.map(function(item) {
+        return [item[0] + ':' + item[1], CSS.supports(item[0], item[1]), item[2]];
+    });
+}
+
+generate_tests(assert_equals, buildTestCases(tests));
+
+</script>
+</body>
+</html>

--- a/css-conditional-3/js/css-supports-utils.js
+++ b/css-conditional-3/js/css-supports-utils.js
@@ -1,0 +1,17 @@
+var parentheticals = [
+// supports_declaration_condition
+["(margin:0)", true],
+
+// nested production
+["((margin:0))", true],
+
+// general_enclosed
+["rgb(0,0,0)", false],
+["(blue)", false]
+];
+
+var compoundParentheticals = [
+["(NOT (margin:0))", false],
+["((margin:0) AND (border:0))", true],
+["((margin:0) OR (border:0))", true],
+];


### PR DESCRIPTION
These tests cover the basics of the CSS.supports functionality piece of the Conditional Rules L3 Specification.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/561)

<!-- Reviewable:end -->
