### PR TITLE
CSS Writing Modes: tests for `text-combine-upright` on fullwidth characters

### DIFF
--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-001.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright on full-width characters</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth">
+<link rel="match" href="full-width-ref.html">
+<meta name="assert" content="When two or more full-width characters are combined, they are first converted to non-full-width characters.">
+<style>
+.vertical-rl {
+  writing-mode: vertical-rl;
+}
+
+.tcu-all {
+  text-combine-upright: all;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-rl">
+  <p><span class="tcu-all">６</span>月<span class="tcu-all">１９</span>日</p>
+  <p>６月<span class="tcu-all">19</span>日</p>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-002.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-002.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright on full-width characters</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-css-text-3-20131010/#full-width">
+<link rel="match" href="full-width-ref.html">
+<meta name="assert" content="When two or more full-width characters are combined, they are first converted to non-full-width characters.">
+<style>
+.vertical-rl {
+  writing-mode: vertical-rl;
+}
+
+.trcu-all {
+  text-combine-upright: all;
+}
+
+.tt-fullwidth {
+  text-transform: full-width;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-rl">
+  <p><span class="tcu-all tt-fullwidth">6</span>月<span class="tcu-all tt-fullwidth">19</span>日</p>
+  <p>６月<span class="tcu-all">19</span>日</p>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-003.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-003.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright on full-width characters</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-fullwidth">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-css-text-3-20131010/#full-width">
+<link rel="match" href="full-width-ref.html">
+<meta name="assert" content="When two or more full-width characters are combined, they are first converted to non-full-width characters.">
+<style>
+.vertical-rl {
+  writing-mode: vertical-rl;
+}
+
+.trcu-all {
+  text-combine-upright: all;
+}
+
+.tcu-digits2 {
+  text-combine-upright: digits 2;
+}
+
+.tt-fullwidth {
+  text-transform: full-width;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-rl">
+  <p><span class="tcu-digits2 tt-fullwidth">6</span>月<span class="tcu-digits2 tt-fullwidth">19</span>日</p>
+  <p>６月<span class="tcu-all">19</span>日</p>
+</div>
+
+</body>
+</html>

--- a/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-ref.html
+++ b/work-in-progress/myakura/css-writing-modes-3/text-combine-upright/full-width-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
+<style>
+.vertical-rl {
+  writing-mode: vertical-rl;
+}
+
+.tcu-all {
+  text-combine-upright: all;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following paragraphs are identical:</p>
+
+<div class="vertical-rl">
+  <p>６月<span class="tcu-all">19</span>日</p>
+  <p>６月<span class="tcu-all">19</span>日</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR is a continuation from https://github.com/w3c/csswg-test/pull/558, which was once merged then reverted. I restored the original file and made following changes.
- add tests and reference to use vertical-rl per suggestion from editor.
- use text-combine-upright: all mainly where possible
- add tcu: all + tt: full-width case as 002 (former 002 is now 003)
