### PR TITLE
Revised text-transform tests without ref test links

### DIFF
--- a/css-text-3/i18n/css3-text-text-transform-001.html
+++ b/css-text-3/i18n/css3-text-text-transform-001.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin1 uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-001-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Latin 1 set when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-002.html
+++ b/css-text-3/i18n/css3-text-text-transform-002.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin1 lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-002-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Latin 1 set when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-003.html
+++ b/css-text-3/i18n/css3-text-text-transform-003.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended Additional, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-003-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Latin Extended Additional Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-004.html
+++ b/css-text-3/i18n/css3-text-text-transform-004.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended Additional, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-004-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Latin Extended Additional Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-005.html
+++ b/css-text-3/i18n/css3-text-text-transform-005.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-A, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-005-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Latin Extended-A Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-006.html
+++ b/css-text-3/i18n/css3-text-text-transform-006.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-A, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-006-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Latin Extended-A Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-007.html
+++ b/css-text-3/i18n/css3-text-text-transform-007.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-B, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-007-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Latin Extended-B Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-007a.html
+++ b/css-text-3/i18n/css3-text-text-transform-007a.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-B, uppercase (additional)</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
 <link rel="match" href="reference/css3-text-text-transform-007a-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all these letters from the Latin Extended-B Unicode block when text-transform is set to uppercase.">

--- a/css-text-3/i18n/css3-text-text-transform-008.html
+++ b/css-text-3/i18n/css3-text-text-transform-008.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-B, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-008-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Latin Extended-B Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-009.html
+++ b/css-text-3/i18n/css3-text-text-transform-009.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-C, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-009-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Latin Extended-C Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-010.html
+++ b/css-text-3/i18n/css3-text-text-transform-010.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-C, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-010-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Latin Extended-C Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-010a.html
+++ b/css-text-3/i18n/css3-text-text-transform-010a.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin Extended-C, lowercase (additional)</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
 <link rel="match" href="reference/css3-text-text-transform-010a-ref.html">
 <meta name='flags' content='font'>
 <meta name="assert" content="The UA will lowercase all these letters from the Latin Extended-C Unicode block when text-transform is set to lowercase.">

--- a/css-text-3/i18n/css3-text-text-transform-011.html
+++ b/css-text-3/i18n/css3-text-text-transform-011.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Full-width Latin, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-011-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable full width Latin letters when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-012.html
+++ b/css-text-3/i18n/css3-text-text-transform-012.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Full-width Latin, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-012-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable full width Latin letters when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-014.html
+++ b/css-text-3/i18n/css3-text-text-transform-014.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek and Coptic, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-014-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Greek and Coptic Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-015.html
+++ b/css-text-3/i18n/css3-text-text-transform-015.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek and Coptic, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-015-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Greek and Coptic Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-016.html
+++ b/css-text-3/i18n/css3-text-text-transform-016.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek Extended, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-016-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Greek Extended Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-017.html
+++ b/css-text-3/i18n/css3-text-text-transform-017.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek Extended, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-017-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Greek Extended Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-018.html
+++ b/css-text-3/i18n/css3-text-text-transform-018.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Cyrillic, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-018-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Cyrillic Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-019.html
+++ b/css-text-3/i18n/css3-text-text-transform-019.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Cyrillic, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-019-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Cyrillic Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-020.html
+++ b/css-text-3/i18n/css3-text-text-transform-020.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Cyrillic Extended, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-020-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Cyrillic Extended Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-021.html
+++ b/css-text-3/i18n/css3-text-text-transform-021.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Cyrillic Extended, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-021-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Cyrillic Extended Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-022.html
+++ b/css-text-3/i18n/css3-text-text-transform-022.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Armenian, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-022-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Armenian Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-023.html
+++ b/css-text-3/i18n/css3-text-text-transform-023.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Armenian, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-023-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Armenian Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-024.html
+++ b/css-text-3/i18n/css3-text-text-transform-024.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Number forms, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-024-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Number forms Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-025.html
+++ b/css-text-3/i18n/css3-text-text-transform-025.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Number forms, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-025-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Number forms Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-026.html
+++ b/css-text-3/i18n/css3-text-text-transform-026.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Enclosed Alphanumerics, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-026-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Enclosed Alphanumerics Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-027.html
+++ b/css-text-3/i18n/css3-text-text-transform-027.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Enclosed Alphanumerics, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-027-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Enclosed Alphanumerics Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-028.html
+++ b/css-text-3/i18n/css3-text-text-transform-028.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Deseret, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-028-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Deseret Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-029.html
+++ b/css-text-3/i18n/css3-text-text-transform-029.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Deseret, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-029-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Deseret Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-030.html
+++ b/css-text-3/i18n/css3-text-text-transform-030.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Georgian, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-030-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase all applicable letters in the Georgian Unicode block when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-031.html
+++ b/css-text-3/i18n/css3-text-text-transform-031.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Georgian, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-031-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase all applicable letters in the Georgian Unicode block when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-032.html
+++ b/css-text-3/i18n/css3-text-text-transform-032.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: German sharp S, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-032-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase the German sharp S as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-033.html
+++ b/css-text-3/i18n/css3-text-text-transform-033.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Latin ligatures, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-033-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase Latin ligatures as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-034.html
+++ b/css-text-3/i18n/css3-text-text-transform-034.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Armenian ligatures, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-034-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase Armenian ligatures as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-035.html
+++ b/css-text-3/i18n/css3-text-text-transform-035.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek specials, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-035-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase Greek characters as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-038.html
+++ b/css-text-3/i18n/css3-text-text-transform-038.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Greek final sigma, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-038-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase Greek final sigma at the end of a word as described in Unicode's SpecialCasing.txt when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-039.html
+++ b/css-text-3/i18n/css3-text-text-transform-039.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Lithuanian, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-039-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase Lithuanian as described in Unicode's SpecialCasing.txt when text-transform is set to lowercase.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-040.html
+++ b/css-text-3/i18n/css3-text-text-transform-040.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Turkish, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-040-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase Turkish as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase and the language is specified as Turkish.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-041.html
+++ b/css-text-3/i18n/css3-text-text-transform-041.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Turkish, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-041-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase Turkish as described in Unicode's SpecialCasing.txt when text-transform is set to lowercase and the language is specified as Turkish.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-042.html
+++ b/css-text-3/i18n/css3-text-text-transform-042.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Azeri, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-042-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will uppercase Azeri as described in Unicode's SpecialCasing.txt when text-transform is set to uppercase and the language is specified as Azeri.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-043.html
+++ b/css-text-3/i18n/css3-text-text-transform-043.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: Azeri, lowercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-043-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The UA will lowercase Azeri as described in Unicode's SpecialCasing.txt when text-transform is set to lowercase and the language is specified as Azeri.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-044.html
+++ b/css-text-3/i18n/css3-text-text-transform-044.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: small kana mappings, hiragana</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-044-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The browser will map small hiragana characters to full sized hiragana for display if text-transform is set to full-size-kana.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-045.html
+++ b/css-text-3/i18n/css3-text-text-transform-045.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: small kana mappings, katakana</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-045-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The browser will map small katakana characters to full sized katakana for display if text-transform is set to full-size-kana.">
 <style type='text/css'>

--- a/css-text-3/i18n/css3-text-text-transform-046.html
+++ b/css-text-3/i18n/css3-text-text-transform-046.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8"/>
 <title>CSS3 Text, text transform: small kana mappings, half-width katakana</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='help' href='http://dev.w3.org/csswg/css-text/#text-transform'>
-
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#text-transform'>
+<link rel="match" href="reference/css3-text-text-transform-046-ref.html">
 <meta name='flags' content=''>
 <meta name="assert" content="The browser will map small half-width katakana characters to full sized half-width katakana for display if text-transform is set to full-size-kana.">
 <style type='text/css'>


### PR DESCRIPTION
These tests should never have tried to link to reftests, since they are font dependent. Where the webfont doesn't cover (ie. recent additions to Unicode) a standard reftest could produce false positives by matching tofu with tofu.

However, these tests do work by presenting visual references on the test page, so that at least the tester's job is significantly helped.

Note that I refer to the editors copy of the spec in these new files, since that is much more advanced than the published version.  I hope that's not a problem.
