### PR TITLE
fixes Webkit bug 135924

### DIFF
--- a/css-shapes-1/shape-outside-invalid-ellipse-002.html
+++ b/css-shapes-1/shape-outside-invalid-ellipse-002.html
@@ -28,7 +28,7 @@
     <script>
     var obj = document.getElementById('shape');
     var val = getComputedStyle(obj).shapeOutside;
-    test(function() {assert_equals(val, "auto", "declaration should not be valid")});
+    test(function() {assert_equals(val, "none", "declaration should not be valid")});
     </script>
 
 </body>

--- a/css-shapes-1/shape-outside-invalid-ellipse-003.html
+++ b/css-shapes-1/shape-outside-invalid-ellipse-003.html
@@ -28,7 +28,7 @@
     <script>
     var obj = document.getElementById('shape');
     var val = getComputedStyle(obj).shapeOutside;
-    test(function() {assert_equals(val, "auto", "declaration should not be valid")});
+    test(function() {assert_equals(val, "none", "declaration should not be valid")});
     </script>
 
 </body>

--- a/css-shapes-1/shape-outside-invalid-ellipse-004.html
+++ b/css-shapes-1/shape-outside-invalid-ellipse-004.html
@@ -29,7 +29,7 @@
 	<script>
 	var obj = document.getElementById('shape');
 	var ellipse = getComputedStyle(obj).shapeOutside;
-	test(function() {assert_equals(ellipse, "auto", "declaration should be Invalid")});
+	test(function() {assert_equals(ellipse, "none", "declaration should be Invalid")});
 	</script>
 
 </body>

--- a/css-shapes-1/shape-outside-invalid-ellipse-005.html
+++ b/css-shapes-1/shape-outside-invalid-ellipse-005.html
@@ -29,7 +29,7 @@
 	<script>
 	var obj = document.getElementById('shape');
 	var ellipse = getComputedStyle(obj).shapeOutside;
-	test(function() {assert_equals(ellipse, "auto", "declaration should be Invalid")});
+	test(function() {assert_equals(ellipse, "none", "declaration should be Invalid")});
 	</script>
 
 </body>

--- a/css-shapes-1/shape-outside-invalid-ellipse-006.html
+++ b/css-shapes-1/shape-outside-invalid-ellipse-006.html
@@ -29,7 +29,7 @@
 	<script>
 	var obj = document.getElementById('shape');
 	var ellipse = getComputedStyle(obj).shapeOutside;
-	test(function() {assert_equals(ellipse, "auto", "declaration should be Invalid")});
+	test(function() {assert_equals(ellipse, "none", "declaration should be Invalid")});
 	</script>
 
 </body>


### PR DESCRIPTION
These tests were just plain wrong - invalid arg...s should always return a none, never auto
