### PR TITLE
One line of the content can't wrap properly around the shape

### DIFF
--- a/css-shapes-1/shape-outside/supported-shapes/polygon/shape-outside-polygon-012.html
+++ b/css-shapes-1/shape-outside/supported-shapes/polygon/shape-outside-polygon-012.html
@@ -51,8 +51,8 @@
         }
         #ref-2 {
             top: 150px;
-            left: 170px;
-            width: 80px;
+            left: 150px;
+            width: 100px;
             height: 20px;
         }
         #ref-3 {
@@ -66,7 +66,7 @@
     <p>The test passes if there is green square and no red.</p>
     <div id="container">
         <div id="test-shape"></div>
-        XXXXXXXXXXXX XXX XXX XXX XXX XXXXXXXX XXXXXX XXXXXX XXXXXX XXXXXXXXXXXX XXXXXXXXXXXX XXXXXXXXXXXX
+        XXXXXXXXXXXX XXX XXX XXX XXX XXXXXXX XXXXXX XXXXXX XXXXXX XXXXXXXXXXXX XXXXXXXXXXXX XXXXXXXXXXXX
     </div>
     <div id="ref-1" class="ref-shape"></div>
     <div id="ref-2" class="ref-shape"></div>


### PR DESCRIPTION
One line of the content can't wrap properly around the shape because it's too wide when shape-margin is respected properly.
Fix for WebKit: http://trac.webkit.org/changeset/172973
