### PR TITLE
[css-grid] Rename grid defining properties

### DIFF
--- a/css-grid-1/grid-layout-auto-tracks.html
+++ b/css-grid-1/grid-layout-auto-tracks.html
@@ -20,8 +20,8 @@
         width: 100px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 100px;
-        grid-definition-rows: auto;
+        grid-template-columns: 100px;
+        grid-template-rows: auto;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-basic.html
+++ b/css-grid-1/grid-layout-basic.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 100px 50px;
+        grid-template-columns: 100px 50px;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-free-space-unit.html
+++ b/css-grid-1/grid-layout-free-space-unit.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 1fr 50px;
+        grid-template-columns: 1fr 50px;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-grid-in-grid.html
+++ b/css-grid-1/grid-layout-grid-in-grid.html
@@ -20,8 +20,8 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 50px 100px;
-        grid-definition-rows: 100px 50px;
+        grid-template-columns: 50px 100px;
+        grid-template-rows: 100px 50px;
       }
       .a {
         background: blue;
@@ -33,8 +33,8 @@
         grid-column: 2;
         grid-row: 1;
         display: grid;
-        grid-definition-columns: 50px 50px;
-        grid-definition-rows: 50px 50px;
+        grid-template-columns: 50px 50px;
+        grid-template-rows: 50px 50px;
       }
       .b1 {
         background: orange;

--- a/css-grid-1/grid-layout-grid-span.html
+++ b/css-grid-1/grid-layout-grid-span.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 50px 50px 50px;
+        grid-template-columns: 50px 50px 50px;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-lines-shorthands.html
+++ b/css-grid-1/grid-layout-lines-shorthands.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: "left" 100px "center" 50px "right";
+        grid-template-columns: "left" 100px "center" 50px "right";
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-lines.html
+++ b/css-grid-1/grid-layout-lines.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: "left" 100px "center" 50px "right";
+        grid-template-columns: "left" 100px "center" 50px "right";
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-placement-shorthands.html
+++ b/css-grid-1/grid-layout-placement-shorthands.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 50px 50px 50px;
+        grid-template-columns: 50px 50px 50px;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-repeat-notation.html
+++ b/css-grid-1/grid-layout-repeat-notation.html
@@ -19,7 +19,7 @@
         width: 450px;
         background: #eee;
         display: grid;
-        grid-definition-columns: repeat(4, 100px) 50px;
+        grid-template-columns: repeat(4, 100px) 50px;
       }
       .a {
         background: blue;

--- a/css-grid-1/grid-layout-z-order-a.html
+++ b/css-grid-1/grid-layout-z-order-a.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 50px 50px 50px;
+        grid-template-columns: 50px 50px 50px;
         color:white;
       }
       .a {

--- a/css-grid-1/grid-layout-z-order-b.html
+++ b/css-grid-1/grid-layout-z-order-b.html
@@ -19,7 +19,7 @@
         width: 150px;
         background: #eee;
         display: grid;
-        grid-definition-columns: 50px 50px 50px;
+        grid-template-columns: 50px 50px 50px;
         color:white;
       }
       .a {


### PR DESCRIPTION
Rename grid-definition-{columns|rows} to grid-template-{columns|rows}.
