### PR TITLE
[css-grid] Fix grid span syntax

### DIFF
--- a/css-grid-1/grid-layout-grid-span.html
+++ b/css-grid-1/grid-layout-grid-span.html
@@ -23,8 +23,7 @@
       }
       .a {
         background: blue;
-        grid-column: 1;
-        grid-column-span: 2;
+        grid-column: 1 / span 2;
         grid-row: 1;
       }
       .b {


### PR DESCRIPTION
The example was using the old syntax for grid span which is not supported anymore.
