### PR TITLE
Fix tests for rect() function on clip property.

### DIFF
--- a/css-masking-1/clip/clip-absolute-positioned-001.html
+++ b/css-masking-1/clip/clip-absolute-positioned-001.html
@@ -6,12 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-absolute-positioned-ref.html">
-    <meta name="assert" content="The clip property should clip elements whose layout are governed
-        by the CSS box model and that are abolutely positioned with 'position: absolute;'.
-        On pass you should see a green box.">
+    <meta name="assert" content="The clip property should clip elements whose
+    layout are governed by the CSS box model and that are abolutely positioned
+    with 'position: absolute;'. On pass you should see a green square and no
+    red.">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="width: 100px; height: 100px; border: solid red 50px; position: absolute; background-color: green; clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-absolute-positioned-002.html
+++ b/css-masking-1/clip/clip-absolute-positioned-002.html
@@ -6,12 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-absolute-positioned-ref.html">
-    <meta name="assert" content="The clip property should clip elements whose layout are governed
-        by the CSS box model and that are abolutely positioned with 'position: fixed;'.
-        On pass you should see a green box.">
+    <meta name="assert" content="The clip property should clip elements whose
+    layout are governed by the CSS box model and that are abolutely positioned
+    with 'position: fixed;'. On pass you should see a green square and no
+    red.">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="width: 100px; height: 100px; border: solid red 50px; position: fixed; background-color: green; clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-negative-values-001.html
+++ b/css-masking-1/clip/clip-negative-values-001.html
@@ -6,12 +6,12 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-full-ref.html">
-    <meta name="assert" content="Negative values are permitted on rect function for clip.
-        Test that whole element is clipped if bottom edge is before top edge.
-        On pass you should see a green box.">
+    <meta name="assert" content="Negative values are permitted on rect function
+    for clip. Test that whole element is clipped if bottom edge is before top
+    edge. On pass you should see a green square and no red.">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="background-color: green; width: 200px; height: 200px;">
         <div style="width: 200px; height: 200px; background-color: red; position: absolute; clip: rect(0, -50px, 200px, 50px);"></div>
     </div>

--- a/css-masking-1/clip/clip-negative-values-002.html
+++ b/css-masking-1/clip/clip-negative-values-002.html
@@ -6,12 +6,12 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-full-ref.html">
-    <meta name="assert" content="Negative values are permitted on rect function for clip.
-        Test that whole element is clipped if right edge is before left edge.
-        On pass you should see a green box with a blue border.">
+    <meta name="assert" content="Negative values are permitted on rect function
+    for clip. Test that whole element is clipped if right edge is before left
+    edge. On pass you should see a green square and no red.">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="background-color: green; width: 200px; height: 200px;">
         <div style="width: 200px; height: 200px; background-color: red; position: absolute; clip: rect(50px, 200px, -50px, 0);"></div>
     </div>

--- a/css-masking-1/clip/clip-negative-values-003.html
+++ b/css-masking-1/clip/clip-negative-values-003.html
@@ -6,12 +6,12 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-vertical-stripe-ref.html">
-    <meta name="assert" content="Negative values are permited on rect function for clip.
-        Test that left edge can be negative.
-        On pass you should see a vertical blue stripe.">
+    <meta name="assert" content="Negative values are permited on rect function
+    for clip. Test that left edge can be negative. On pass you should see a
+    vertical blue stripe.">
 </head>
 <body>
-    <p>The test passes if there is a vertical blue stripe.</p>
+    <p>The test passes if there is only a vertical blue stripe.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(0, 50px, 200px, -50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-negative-values-004.html
+++ b/css-masking-1/clip/clip-negative-values-004.html
@@ -6,12 +6,12 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-horizontal-stripe-ref.html">
-    <meta name="assert" content="Negative values are permited on rect function for clip.
-        Test that top edge can be negative.
-        On pass you should see a horizontal blue stripe.">
+    <meta name="assert" content="Negative values are permited on rect function
+    for clip. Test that top edge can be negative. On pass you should see a
+    horizontal blue stripe.">
 </head>
 <body>
-    <p>The test passes if there is a horizontal blue stripe.</p>
+    <p>The test passes if there is only a horizontal blue stripe.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(-50px, 200px, 50px, 0);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-no-clipping-001.html
+++ b/css-masking-1/clip/clip-no-clipping-001.html
@@ -6,11 +6,11 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should on 'auto'.
-        On pass you should see a green box with a blue border.">
+    <meta name="assert" content="The clip property should on 'auto'. On pass
+    you should see a green box with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: auto"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-no-clipping-002.html
+++ b/css-masking-1/clip/clip-no-clipping-002.html
@@ -6,11 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should not clip overflowing content of elements whose layout are governed
-        by the CSS box model, the position is absolute and the clip value is 'auto'. On pass you should see a a blue box overlapped by a samller green box.">
+    <meta name="assert" content="The clip property should not clip overflowing
+    content of elements whose layout are governed by the CSS box model, the
+    position is absolute and the clip value is 'auto'. On pass you should see a
+    a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; position: absolute; clip: auto;">
         <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green;"></div>
     </div>

--- a/css-masking-1/clip/clip-not-absolute-positioned-001.html
+++ b/css-masking-1/clip/clip-not-absolute-positioned-001.html
@@ -6,11 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should be ignored on elements whose layout are governed
-        by the CSS box model and are not abolutely positioned. On pass you should see a green box with a blue border.">
+    <meta name="assert" content="The clip property should be ignored on
+    elements whose layout are governed by the CSS box model and are not
+    abolutely positioned. On pass you should see a green square with a blue
+    border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-not-absolute-positioned-002.html
+++ b/css-masking-1/clip/clip-not-absolute-positioned-002.html
@@ -6,12 +6,14 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should be ignored on elements whose layout are governed
-        by the CSS box model and are not abolutely positioned. Creating a stacking context with z-index does
-        not influence clipping behavior. On pass you should see a green box with a blue border.">
+    <meta name="assert" content="The clip property should be ignored on
+    elements whose layout are governed by the CSS box model and are not
+    abolutely positioned. Creating a stacking context with z-index does not
+    influence clipping behavior. On pass you should see a green box square with
+    a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; z-index: 10; clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-not-absolute-positioned-003.html
+++ b/css-masking-1/clip/clip-not-absolute-positioned-003.html
@@ -6,12 +6,14 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should be ignored on elements whose layout are governed
-        by the CSS box model and are not abolutely positioned. Creating a 3d rednering context does
-        not influence clipping behavior. On pass you should see a green box with a blue border.">
+    <meta name="assert" content="The clip property should be ignored on
+    elements whose layout are governed by the CSS box model and are not
+    abolutely positioned. Creating a 3d rednering context does not influence
+    clipping behavior. On pass you should see a green square with a blue
+    border.">
 </head>
 <body style="perspective: 400px;">
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; transform-style: preserve-3d; transform: translate3d(0, 0, 0); clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-not-absolute-positioned-004.html
+++ b/css-masking-1/clip/clip-not-absolute-positioned-004.html
@@ -6,12 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="The clip property should be ignored on elements whose layout are governed
-        by the CSS box model and are not abolutely positioned. position: relative does
-        not influence clipping behavior. On pass you should see a green box with a blue border.">
+    <meta name="assert" content="The clip property should be ignored on
+    elements whose layout are governed by the CSS box model and are not
+    abolutely positioned. position: relative does not influence clipping
+    behavior. On pass you should see a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: relative; clip: rect(50px, 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-rect-auto-001.html
+++ b/css-masking-1/clip/clip-rect-auto-001.html
@@ -6,12 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-overflow-hidden-ref.html">
-    <meta name="assert" content="A value of 'auto' in the rect function is equal to the certain edge of the border box.
-        The content should be clipped to the border box.
-        On pass you see a blue box and a smaller green box in the bottom right corner of the blue box.">
+    <meta name="assert" content="A value of 'auto' in the rect function is
+    equal to the certain edge of the border box. The content should be clipped
+    to the border box. On pass you see a blue square and a smaller green square
+    in the bottom right corner of the blue square.">
 </head>
 <body>
-    <p>The test passes if there is a blue box and a smaller green box in the bottom right corner of the blue box.</p>
+    <p>The test passes if there is a blue square and a smaller green square in the bottom right corner of the blue square   .</p>
     <div style="position: absolute; clip: rect(auto, auto, auto, auto); width: 100px; height: 100px;">
         <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green;"></div>
     </div>

--- a/css-masking-1/clip/clip-rect-auto-002.html
+++ b/css-masking-1/clip/clip-rect-auto-002.html
@@ -6,12 +6,13 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="A value of 'auto' in the rect function is equal to the certain edge of the border box.
-        The box shadow should be clipped, since it is painted outside the border box.
-        On pass you should see a green box with a blue border.">
+    <meta name="assert" content="A value of 'auto' in the rect function is
+    equal to the certain edge of the border box. The box shadow should be
+    clipped, since it is painted outside the border box. On pass you should see
+    a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(auto, auto, auto, auto); box-shadow: 0 0 10px red;"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-rect-auto-003.html
+++ b/css-masking-1/clip/clip-rect-auto-003.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-rect-top-ref.html">
-    <meta name="assert" content="A value of 'auto' for 'top' in the rect function is equal to the top edge of the border box.
-        The box shadow should be clipped, since it is painted outside the border box.
-        On pass you should see a horizontal green stripe under a horizontal blue stripe.">
+    <meta name="assert" content="A value of 'auto' for 'top' in the rect
+    function is equal to the top edge of the border box. The box shadow should
+    be clipped, since it is painted outside the border box. On pass you should see a horizontal green stripe under a horizontal blue stripe.">
 </head>
 <body>
     <p>The test passes if there is a horizontal green stripe under a horizontal blue stripe.</p>

--- a/css-masking-1/clip/clip-rect-auto-004.html
+++ b/css-masking-1/clip/clip-rect-auto-004.html
@@ -6,9 +6,10 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-rect-right-ref.html">
-    <meta name="assert" content="A value of 'auto' for 'right' in the rect function is equal to the top edge of the border box.
-        The box shadow should be clipped, since it is painted outside the border box.
-        On pass you should see a vertical blue stripe on the right side of a vertical green stripe.">
+    <meta name="assert" content="A value of 'auto' for 'right' in the rect
+    function is equal to the top edge of the border box. The box shadow should
+    be clipped, since it is painted outside the border box. On pass you should
+    see a vertical blue stripe on the right side of a vertical green stripe.">
 </head>
 <body>
     <p>The test passes if there is a vertical blue stripe on the right side of a vertical green stripe.</p>

--- a/css-masking-1/clip/clip-rect-auto-005.html
+++ b/css-masking-1/clip/clip-rect-auto-005.html
@@ -6,9 +6,10 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-rect-bottom-ref.html">
-    <meta name="assert" content="A value of 'auto' for 'bottom' in the rect function is equal to the top edge of the border box.
-        The box shadow should be clipped, since it is painted outside the border box.
-        On pass you should see a horizontal blue stripe under a horizontal green stripe.">
+    <meta name="assert" content="A value of 'auto' for 'bottom' in the rect
+    function is equal to the top edge of the border box. The box shadow should
+    be clipped, since it is painted outside the border box. On pass you should
+    see a horizontal blue stripe under a horizontal green stripe.">
 </head>
 <body>
     <p>The test passes if there is a horizontal blue stripe under a horizontal green stripe.</p>

--- a/css-masking-1/clip/clip-rect-auto-006.html
+++ b/css-masking-1/clip/clip-rect-auto-006.html
@@ -6,9 +6,10 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-rect-left-ref.html">
-    <meta name="assert" content="A value of 'auto' for 'left' in the rect function is equal to the top edge of the border box.
-        The box shadow should be clipped, since it is painted outside the border box.
-        On pass you should see a vertical green stripe on the right side of a vertical blue stripe.">
+    <meta name="assert" content="A value of 'auto' for 'left' in the rect
+    function is equal to the top edge of the border box. The box shadow should
+    be clipped, since it is painted outside the border box. On pass you should
+    see a vertical green stripe on the right side of a vertical blue stripe.">
 </head>
 <body>
     <p>The test passes if there is a vertical green stripe on the right side of a vertical blue stripe.</p>

--- a/css-masking-1/clip/clip-rect-comma-001.html
+++ b/css-masking-1/clip/clip-rect-comma-001.html
@@ -5,12 +5,13 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-absolute-positioned-ref.html">
-    <meta name="assert" content="Values for rect function on clip can be white space or comma separated, but not both. Otherwise the
-        property setting gets ignored. Testing rect function with white space separation.
-        On pass you should see a green box.">
+    <meta name="assert" content="Values for rect function on clip can be white
+    space or comma separated, but not both. Otherwise the property setting gets
+    ignored. Testing rect function with white space separation. On pass you
+    should see a green square and no red.">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
-    <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(50px 150px 150px 50px);"></div>
+    <p>The test passes if there is a green square and no red.</p>
+    <div style="width: 100px; height: 100px; border: solid red 50px; background-color: green; position: absolute; clip: rect(50px 150px 150px 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-rect-comma-002.html
+++ b/css-masking-1/clip/clip-rect-comma-002.html
@@ -5,12 +5,13 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="Values for rect function on clip can be white space or comma separated, but not both. Otherwise the
-        property setting gets ignored. Testing rect function without comma separation between 1st and 2nd value.
-        On pass you should see a vertical green stripe on the right side of a vertical blue stripe.">
+    <meta name="assert" content="Values for rect function on clip can be white
+    space or comma separated, but not both. Otherwise the property setting gets
+    ignored. Testing rect function without comma separation between 1st and 2nd
+    value. On pass you should see a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
-    <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(50px 150px, 150px, 50px);"></div>
+    <p>The test passes if there is a green square with a blue border.</p>
+    <div style="width: 100px; height: 100px; border: solid red 50px; background-color: green; position: absolute; clip: rect(50px 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-rect-comma-003.html
+++ b/css-masking-1/clip/clip-rect-comma-003.html
@@ -5,12 +5,13 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="Values for rect function on clip can be white space or comma separated, but not both. Otherwise the
-        property setting gets ignored. Testing rect function without comma separation between 2nd and 3rd value.
-        On pass you should see a vertical green stripe on the right side of a vertical blue stripe.">
+    <meta name="assert" content="Values for rect function on clip can be white
+    space or comma separated, but not both. Otherwise the property setting gets
+    ignored. Testing rect function without comma separation between 2nd and 3rd
+    value. On pass you should see a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(50px, 150px 150px, 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/clip-rect-comma-004.html
+++ b/css-masking-1/clip/clip-rect-comma-004.html
@@ -5,12 +5,13 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-no-clipping-ref.html">
-    <meta name="assert" content="Values for rect function on clip can be white space or comma separated, but not both. Otherwise the
-        property setting gets ignored. Testing rect function without comma separation between 3rd and 4th value.
-        On pass you should see a vertical green stripe on the right side of a vertical blue stripe.">
+    <meta name="assert" content="Values for rect function on clip can be white
+    space or comma separated, but not both. Otherwise the property setting gets
+    ignored. Testing rect function without comma separation between 3rd and 4th
+    value. On pass you should see a green square with a blue border.">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(50px, 150px, 150px 50px);"></div>
 </body>
 </html>

--- a/css-masking-1/clip/reference/clip-absolute-positioned-ref.html
+++ b/css-masking-1/clip/reference/clip-absolute-positioned-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="width: 100px; height: 100px; border: 50px solid white; background-color: green;"></div>
 </body>
 </html>

--- a/css-masking-1/clip/reference/clip-full-ref.html
+++ b/css-masking-1/clip/reference/clip-full-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a green box.</p>
+    <p>The test passes if there is a green square and no red.</p>
     <div style="width: 200px; height: 200px; background-color: green;"></div>
 </body>
 </html>

--- a/css-masking-1/clip/reference/clip-horizontal-stripe-ref.html
+++ b/css-masking-1/clip/reference/clip-horizontal-stripe-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a horizontal blue stripe.</p>
+    <p>The test passes if there is only a vertical blue stripe.</p>
     <div style="width: 200px; height: 50px; background-color: blue;"></div>
 </body>
 </html>

--- a/css-masking-1/clip/reference/clip-no-clipping-ref.html
+++ b/css-masking-1/clip/reference/clip-no-clipping-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a green box with a blue border.</p>
+    <p>The test passes if there is a green square with a blue border.</p>
     <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green;"></div>
 </body>
 </html>

--- a/css-masking-1/clip/reference/clip-overflow-hidden-ref.html
+++ b/css-masking-1/clip/reference/clip-overflow-hidden-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a blue box and a smaller green box in the bottom right corner of the blue box.</p>
+    <p>The test passes if there is a blue square and a smaller green square in the bottom right corner of the blue square.</p>
     <div style="overflow: hidden; width: 100px; height: 100px;">
     	<div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green;"></div>
     </div>

--- a/css-masking-1/clip/reference/clip-vertical-stripe-ref.html
+++ b/css-masking-1/clip/reference/clip-vertical-stripe-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is a vertical blue stripe.</p>
+    <p>The test passes if there is only a vertical blue stripe.</p>
     <div style="width: 50px; height: 200px; background-color: blue;"></div>
 </body>
 </html>


### PR DESCRIPTION
Made the test descriptions more specific, fixed one or two description texts.
