### PR TITLE
Tests for the formatting of ::first-letter

### DIFF
--- a/css-pseudo-4/first-letter-001-ref.html
+++ b/css-pseudo-4/first-letter-001-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8"> 
+	<title>CSS Reference File</title>
+	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+	<style>
+	div {
+		font-size: 50px;
+		position: absolute;
+		left: 30px;
+		top: 50px;
+	}
+	div span {
+		color: green;
+		background: green;
+		float: left;
+	}
+	</style>
+</head>
+<body>
+	<p>Test passes if there is a <strong>filled green rectangle</strong> and <strong>no red</strong>.</p>
+	<div><span>a</span></div>
+</body>
+</html>

--- a/css-pseudo-4/first-letter-001.html
+++ b/css-pseudo-4/first-letter-001.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>CSS Test: ::first-letter formatting</title>
+	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+	<link rel="match" href="first-letter-001-ref.html">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<meta name="flags" content="">
+	<meta name="assert" content="Test checks that a floated ::first-letter follows the usual formating rules for floats.">
+	<style>
+	div {
+		font-size: 50px;
+		position: absolute;
+		left: 30px;
+		top: 50px;
+		background: red;
+	}
+	span {
+		background : white;
+	}
+	div::first-letter {
+		color: green;
+		background: green;
+		float: left;
+	}
+	</style>
+</head>
+<body>
+	<p>Test passes if there is a <strong>filled green rectangle</strong> and <strong>no red</strong>.</p>
+	<div>a<span>&nbsp;</span></div>
+</body>
+</html>

--- a/css-pseudo-4/first-letter-001.html
+++ b/css-pseudo-4/first-letter-001.html
@@ -5,7 +5,7 @@
 	<title>CSS Test: ::first-letter formatting</title>
 	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
 	<link rel="match" href="first-letter-001-ref.html">
-	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo-4/#first-letter-styling">
 	<meta name="flags" content="">
 	<meta name="assert" content="Test checks that a floated ::first-letter follows the usual formating rules for floats.">
 	<style>

--- a/css-pseudo-4/first-letter-002.html
+++ b/css-pseudo-4/first-letter-002.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8"> 
+	<title>CSS Test: ::first-letter formatting</title>
+	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+	<link rel="match" href="first-letter-001-ref.html">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<meta name="flags" content="">
+	<meta name="assert" content="Test checks that a floated ::first-letter is formatted identically to a floated non-pseudo element with the same content.">
+	<style>
+	div {
+		font-size: 50px;
+		position: absolute;
+		left: 30px;
+		top: 50px;
+	}
+	#d1 span {
+		color: red;
+		background: red;
+		float: left;
+	}
+	#d2::first-letter {
+		color: green;
+		background: green;
+		float: left;
+	}
+	</style>
+</head>
+<body>
+	<p>Test passes if there is a <strong>filled green rectangle</strong> and <strong>no red</strong>.</p>
+	<div id="d1"><span>a</span></div>
+	<div id="d2">a</div>
+</body>
+</html>

--- a/css-pseudo-4/first-letter-002.html
+++ b/css-pseudo-4/first-letter-002.html
@@ -5,7 +5,7 @@
 	<title>CSS Test: ::first-letter formatting</title>
 	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
 	<link rel="match" href="first-letter-001-ref.html">
-	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo-4/#first-letter-styling">
 	<meta name="flags" content="">
 	<meta name="assert" content="Test checks that a floated ::first-letter is formatted identically to a floated non-pseudo element with the same content.">
 	<style>

--- a/css-pseudo-4/first-letter-003.html
+++ b/css-pseudo-4/first-letter-003.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8"> 
+	<title>CSS Test: ::first-letter formatting</title>
+	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+	<link rel="match" href="first-letter-001-ref.html">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<meta name="flags" content="">
+	<meta name="assert" content="Test checks that a floated ::first-letter is formatted identically to a floated non-pseudo element with the same content.">
+	<style>
+	div {
+		font-size: 50px;
+		position: absolute;
+		left: 30px;
+		top: 50px;
+	}
+	#d1::first-letter {
+		color: red;
+		background: red;
+		float: left;
+	}
+	#d2 span {
+		color: green;
+		background: green;
+		float: left;
+	}
+	</style>
+</head>
+<body>
+	<p>Test passes if there is a <strong>filled green rectangle</strong> and <strong>no red</strong>.</p>
+	<div id="d1">a</div>
+	<div id="d2"><span>a</span></div>
+</body>
+</html>

--- a/css-pseudo-4/first-letter-003.html
+++ b/css-pseudo-4/first-letter-003.html
@@ -5,7 +5,7 @@
 	<title>CSS Test: ::first-letter formatting</title>
 	<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
 	<link rel="match" href="first-letter-001-ref.html">
-	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo/#first-letter-styling">
+	<link rel="help" href="http://dev.w3.org/csswg/css-pseudo-4/#first-letter-styling">
 	<meta name="flags" content="">
 	<meta name="assert" content="Test checks that a floated ::first-letter is formatted identically to a floated non-pseudo element with the same content.">
 	<style>


### PR DESCRIPTION
Previous levels of CSS gave extra flexibility to User Agents to layout
::first-letter in ways that made sense for Drop Caps. As this did not
work interoperably and better ways to do Drop Caps are being introduced,
this possibility has been disallowed. These tests check that conventional
layout is being applied to the ::first-letter pseudo.