### PR TITLE
Tests for the directional nav-* properties

### DIFF
--- a/css-ui-3/nav-dir-missing-1.html
+++ b/css-ui-3/nav-dir-missing-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - unkown element id</title>
+<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that an unknow element id used as the value of the 'nav-right' property value does not hinder normal spacial navigation.">
+<style>
+#start {
+nav-right: #foo;
+}
+</style>
+</head>
+<body>
+	<p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+	<!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+	     In the SmartTV emulator, use the keypad in the GUI. -->
+	<p>Test passes if navigating right moves the focus to the "FINISH" link.</p>
+
+	<a href="" id="start">START</a> <a href="" id="finish">FINISH</a>
+</body></html>

--- a/css-ui-3/nav-dir-missing-2.html
+++ b/css-ui-3/nav-dir-missing-2.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - unkown element id</title>
+<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that an unknow element id used as the value of the 'nav-left' property value does not hinder normal spacial navigation.">
+<style>
+#start {
+nav-left: #foo;
+}
+</style>
+</head>
+<body>
+	<p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+	<!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+	     In the SmartTV emulator, use the keypad in the GUI. -->
+	<p>Test passes if navigating left moves the focus to the "FINISH" link.</p>
+
+	<a href="" id="finish">FINISH</a> <a href="" id="start">START</a>
+</body></html>

--- a/css-ui-3/nav-dir-missing-3.html
+++ b/css-ui-3/nav-dir-missing-3.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - unkown element id</title>
+<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that an unknow element id used as the value of the 'nav-down' property value does not hinder normal spacial navigation.">
+<style>
+#start {
+nav-down: #foo;
+}
+</style>
+</head>
+<body>
+	<p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+	<!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+	     In the SmartTV emulator, use the keypad in the GUI. -->
+	<p>Test passes if navigating down moves the focus to the "FINISH" link.</p>
+
+	<a href="" id="start">START</a><br>
+	<a href="" id="finish">FINISH</a>
+</body></html>

--- a/css-ui-3/nav-dir-missing-4.html
+++ b/css-ui-3/nav-dir-missing-4.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: Directional Focus Navigation - unkown element id</title>
+<link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#nav-dir">
+<meta name="flags" content="interact">
+<meta name="assert" content="Test checks that an unknow element id used as the value of the 'nav-up' property value does not hinder normal spacial navigation.">
+<style>
+#start {
+nav-up: #foo;
+}
+</style>
+</head>
+<body>
+	<p>First, use directional navigation to navigate the focus to the "START" link below.</p>
+	<!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
+	     In the SmartTV emulator, use the keypad in the GUI. -->
+	<p>Test passes if navigating up moves the focus to the "FINISH" link.</p>
+
+	<a href="" id="finish">FINISH</a><br>
+	<a href="" id="start">START</a>
+</body></html>


### PR DESCRIPTION
This checks that normal spacial navigation works correctly if no element
matches the id selector used in the nav-* properties.

At the time of making this pull request, this requirement is only implied in the TR draft. The normative statement has been added to the editor's draft.