### PR TITLE
CSS Writing Modes: add tests for text-combine-upright

### DIFF
--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p>x</p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxx</p>
+  <p>xxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxxx</p>
+  <p>xxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxxxx</p>
+  <p>xxxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="mismatch" href="horizontal-ahem-1x1-notref.html">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p>x</p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="mismatch" href="horizontal-ahem-1x3-notref.html">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxx</p>
+  <p>xxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="mismatch" href="horizontal-ahem-1x4-notref.html">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxxx</p>
+  <p>xxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="mismatch" href="horizontal-ahem-1x5-notref.html">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p>xxxxx</p>
+  <p>xxxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-all-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-002.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: all</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: all' combines all characters inside the element which the declaration applied horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-all-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: all</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: all' combines all characters inside the element which the declaration applied horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: all;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">ABC</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-all-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-003.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: all</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: all' combines all characters inside the element which the declaration applied horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-all-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: all</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: all' combines all characters inside the element which the declaration applied horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: all;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">ABCDE</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits2-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 2 + two digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 2' combines two ASCII digits horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 2;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">12</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits2-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-002.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 2 + two digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 2' combines two ASCII digits horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-digits2-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-003.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 2 + three digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x3-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x3-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 2' does not combine digits that are greater than two.">

--- a/css-writing-modes-3/text-combine-upright/value-digits2-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 2 + three digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x3-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x3-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 2' does not combine digits that are greater than two.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 2;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p><span class="tcy">123</span></p>
+  <p>xxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-001.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 3 + two digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 3' combines two ASCII digits horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-digits3-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 3 + two digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 3' combines two ASCII digits horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 3;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">12</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 3 + three digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 3' combines three ASCII digits horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 3;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">123</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-002.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 3 + three digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 3' combines three ASCII digits horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-digits3-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 3 + four digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x4-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x4-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 3' does not combine digits that are greater than three.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 3;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p><span class="tcy">1234</span></p>
+  <p>xxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-003.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 3 + four digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x4-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x4-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 3' does not combine digits that are greater than three.">

--- a/css-writing-modes-3/text-combine-upright/value-digits4-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-001.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 4 + three digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 4' combines three ASCII digits horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-digits4-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 4 + three digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 4' combines three ASCII digits horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 4;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">123</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits4-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 4 + four digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x1-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 4' combines four ASCII digits horizontally.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 4;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if there are two squares:</p>
+
+<div class="test">
+  <p><span class="tcy">1234</span></p>
+  <p>x</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-digits4-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-002.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 4 + four digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x1-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x1-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 4' combines four ASCII digits horizontally.">

--- a/css-writing-modes-3/text-combine-upright/value-digits4-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-003.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: digits 4 + five digits</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x5-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x5-notref.html">
 <meta name="assert" content="'text-combine-upright: digits 4' does not combine digits that are greater than four.">

--- a/css-writing-modes-3/text-combine-upright/value-digits4-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: digits 4 + five digits</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x5-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x5-notref.html">
+<meta name="assert" content="'text-combine-upright: digits 4' does not combine digits that are greater than four.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: digits 4;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p><span class="tcy">12345</span></p>
+  <p>xxxxx</p>
+</div>
+
+</body>
+</html>

--- a/css-writing-modes-3/text-combine-upright/value-none-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-none-001.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Writing Modes: text-combine-upright: none</title>
 <link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
-<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright">
 <link rel="match" href="reference/vertical-ahem-1x3-ref.html">
 <link rel="mismatch" href="reference/horizontal-ahem-1x3-notref.html">
 <meta name="assert" content="'text-combine-upright: none' does not combine any characters in any circumstance.">

--- a/css-writing-modes-3/text-combine-upright/value-none-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-none-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Writing Modes: text-combine-upright: none</title>
+<link rel="author" title="Masataka Yakura" href="https://google.com/+MasatakaYakura">
+<link rel="help" href="http://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#text-combine-upright">
+<link rel="match" href="reference/vertical-ahem-1x3-ref.html">
+<link rel="mismatch" href="reference/horizontal-ahem-1x3-notref.html">
+<meta name="assert" content="'text-combine-upright: none' does not combine any characters in any circumstance.">
+<meta name="flags" content="ahem">
+<style>
+.test {
+  writing-mode: vertical-rl;
+  font-size: 100px;
+  font-family: Ahem;
+}
+
+.tcy {
+  text-combine-upright: none;
+}
+</style>
+</head>
+<body>
+
+<p>Test passes if the following rectangles are identical:</p>
+
+<div class="test">
+  <p><span class="tcy">A01</span></p>
+  <p>xxx</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
add rendering tests of text-combine-upright that do not requre tailored font.

* value-all-002.html
* value-all-003.html
* value-digits2-002.html
* value-digits2-003.html
* value-digits3-001.html
* value-digits3-002.html
* value-digits3-003.html
* value-digits4-001.html
* value-digits4-002.html
* value-digits4-003.html
* value-none-001.html
* reference/horizontal-ahem-1x1-notref.html
* reference/horizontal-ahem-1x3-notref.html
* reference/horizontal-ahem-1x4-notref.html
* reference/horizontal-ahem-1x5-notref.html
* reference/vertical-ahem-1x1-ref.html
* reference/vertical-ahem-1x3-ref.html
* reference/vertical-ahem-1x4-ref.html
* reference/vertical-ahem-1x5-ref.html

Note that value-all-001.html and value-digits2-001.html are missing: these require a font.

BUG: https://github.com/w3c/csswg-test/issues/568