### PR TITLE
[css-shapes] Make testharness tests work in Blink's test runner

### DIFF
--- a/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-001.html
+++ b/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-001.html
@@ -11,15 +11,14 @@
                                 simple radial gradient."/>
     <style type="text/css">
         body { margin: 0; }
-        .container {
+        #test {
+            color: green;
+            visibility: hidden;
             width: 200px;
             height: 200px;
             font-family: Ahem;
             font-size: 10px;
             line-height: 1;
-        }
-        #test {
-            color: green;
         }
         #gradient {
             float: left;
@@ -30,10 +29,7 @@
     </style>
 </head>
 <body>
-    <p>
-        The test passes if you see green boxes following the contour of a circle. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         x</br>
         <div id="gradient"></div>
         <span id='test0'>x</span><br/>

--- a/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-002.html
+++ b/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-002.html
@@ -12,15 +12,14 @@
                                 is applied."/>
     <style type="text/css">
         body { margin: 0; }
-        .container {
+        #test {
+            color: green;
+            visibility: hidden;
             width: 200px;
             height: 200px;
             font-family: Ahem;
             font-size: 10px;
             line-height: 1;
-        }
-        #test {
-            color: green;
         }
         #gradient {
             float: left;
@@ -32,10 +31,7 @@
     </style>
 </head>
 <body>
-    <p>
-        The test passes if you see green boxes following the contour of a circle. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         x</br>
         <div id="gradient"></div>
         <span id='test0'>x</span><br/>

--- a/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-003.html
+++ b/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-003.html
@@ -13,15 +13,14 @@
                                 and shape-image threshold are applied."/>
     <style type="text/css">
         body { margin: 0; }
-        .container {
+        #test {
+            color: green;
+            visibility: hidden;
             width: 200px;
             height: 200px;
             font-family: Ahem;
             font-size: 10px;
             line-height: 1;
-        }
-        #test {
-            color: green;
         }
         #gradient {
             float: left;
@@ -34,10 +33,7 @@
     </style>
 </head>
 <body>
-    <p>
-        The test passes if you see green boxes following the contour of a circle. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         x</br>
         <div id="gradient"></div>
         <span id='test0'>x</span><br/>

--- a/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-004.html
+++ b/css-shapes-1/shape-outside/shape-image/gradients/shape-outside-radial-gradient-004.html
@@ -12,16 +12,15 @@
                                 shape-image-threshold is applied."/>
     <style type="text/css">
         body { margin: 0; }
-        .container {
+        #test {
+            color: green;
+            visibility: hidden;
             text-align: right;
             width: 200px;
             height: 200px;
             font-family: Ahem;
             font-size: 10px;
             line-height: 1;
-        }
-        #test {
-            color: green;
         }
         #gradient {
             float: right;
@@ -33,10 +32,7 @@
     </style>
 </head>
 <body>
-    <p>
-        The test passes if you see green boxes following the contour of a circle. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         x</br>
         <div id="gradient"></div>
         <span id='test0'>x</span><br/>

--- a/css-shapes-1/spec-examples/shape-outside-010.html
+++ b/css-shapes-1/spec-examples/shape-outside-010.html
@@ -13,14 +13,13 @@
      <!-- This test is derived from Example 7 in this version of the spec:
           http://www.w3.org/TR/2014/WD-css-shapes-1-20140211/ -->
     <style type="text/css">
-        .container {
-          font-family: Ahem;
-          font-size: 20px;
-          line-height: 2em;
-        }
         #test {
             width: 400px;
             color: green;
+            visibility: hidden;
+            font-family: Ahem;
+            font-size: 20px;
+            line-height: 2em;
         }
         #image {
             float: left;
@@ -32,11 +31,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the circle,
-        the long green bar is beneath the circle, and no bars intersect the circle. There
-        should be no red.
-    </p>
     <div id="test" class="container">
         <img id="image" src="support/circle-no-shadow.png"/>
         <span id="line-0">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-011.html
+++ b/css-shapes-1/spec-examples/shape-outside-011.html
@@ -13,14 +13,13 @@
     <!-- This test is derived from Example 7 in this version of the spec:
          http://www.w3.org/TR/2014/WD-css-shapes-1-20140211/ -->
     <style type="text/css">
-        .container {
-          width: 400px;
-          font-family: Ahem;
-          font-size: 20px;
-          line-height: 2em;
-        }
         #test {
             color: green;
+            visibility: hidden;
+            width: 400px;
+            font-family: Ahem;
+            font-size: 20px;
+            line-height: 2em;
         }
         #image {
             float: left;
@@ -32,11 +31,7 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the green horizontal bars are to the right of the circle,
-        and no bars intersect the circle's shadow. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         <img id="image" src="support/circle-shadow.png"/>
         <span id="line-0">XXXXXX</span>
         <span id="line-1">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-012.html
+++ b/css-shapes-1/spec-examples/shape-outside-012.html
@@ -15,14 +15,13 @@
     <!-- This test is derived from Example 7 in this version of the spec:
          http://www.w3.org/TR/2014/WD-css-shapes-1-20140211/ -->
     <style type="text/css">
-        .container {
-          width: 400px;
-          font-family: Ahem;
-          font-size: 20px;
-          line-height: 2em;
-        }
         #test {
             color: green;
+            visibility: hidden;
+            width: 400px;
+            font-family: Ahem;
+            font-size: 20px;
+            line-height: 2em;
         }
         #test-image {
             float: left;
@@ -35,12 +34,7 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the circle, all
-        intersect the shadow, none intersect the circle and the long green bar is beneath the
-        circle. There should be no red.
-    </p>
-    <div id="test" class="container">
+    <div id="test">
         <img id="test-image" src="support/circle-shadow.png"/>
         <span id="line-0">XXXXXX</span>
         <span id="line-1">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-013.html
+++ b/css-shapes-1/spec-examples/shape-outside-013.html
@@ -17,6 +17,7 @@
             position: relative;
             width: 400px;
             color: green;
+            visibility: hidden;
             font-family: Ahem;
             font-size: 20px;
             line-height: 2em;
@@ -42,11 +43,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the circle,
-        the long green bar is beneath the circle, and no bars intersect the circle. There
-        should be no red.
-    </p>
     <div id="test">
         <img id="test-image" src="support/circle-no-shadow.png"/>
         <div id="margin-circle"></div>

--- a/css-shapes-1/spec-examples/shape-outside-014.html
+++ b/css-shapes-1/spec-examples/shape-outside-014.html
@@ -14,6 +14,7 @@
     <style type="text/css">
         #test {
             color: green;
+            visibility: hidden;
             position: relative;
             width: 400px;
             font-family: Ahem;
@@ -46,10 +47,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the shape,
-        the long green bar is beneath it, and no bars intersect it. There should be no red.
-    </p>
     <div id="test" class="container">
         <div id="box"></div>
         <div id="border-shape"></div>

--- a/css-shapes-1/spec-examples/shape-outside-015.html
+++ b/css-shapes-1/spec-examples/shape-outside-015.html
@@ -15,6 +15,7 @@
         #test {
             width: 400px;
             color: green;
+            visibility: hidden;
             font-family: Ahem;
             font-size: 20px;
             line-height: 2em;
@@ -34,10 +35,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the shape,
-        the long green bar is beneath it, and no bars intersect it. There should be no red.
-    </p>
     <div id="test">
         <div id="box"></div>
         <span id="line-0">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-016.html
+++ b/css-shapes-1/spec-examples/shape-outside-016.html
@@ -14,6 +14,7 @@
     <style type="text/css">
         #test {
             color: green;
+            visibility: hidden;
             width: 400px;
             font-family: Ahem;
             font-size: 20px;
@@ -34,10 +35,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the shape,
-        the long green bar is beneath it, and no bars intersect it. There should be no red.
-    </p>
     <div id="test">
         <div id="box"></div>
         <span id="line-0">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-017.html
+++ b/css-shapes-1/spec-examples/shape-outside-017.html
@@ -14,6 +14,7 @@
     <style type="text/css">
         #test {
             color: green;
+            visibility: hidden;
             width: 400px;
             font-family: Ahem;
             font-size: 20px;
@@ -33,10 +34,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the shape,
-        the long green bar is beneath it, and no bars intersect it. There should be no red.
-    </p>
     <div id="test">
         <div id="box"></div>
         <span id="line-0">XXXXXX</span>

--- a/css-shapes-1/spec-examples/shape-outside-018.html
+++ b/css-shapes-1/spec-examples/shape-outside-018.html
@@ -15,6 +15,7 @@
         #test {
             position: relative;
             color: green;
+            visibility: hidden;
             width: 300px;
             font-family: Ahem;
             font-size: 20px;
@@ -39,10 +40,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the longest green horizontal bar is beneath the triangle and the
-        rest of them are to its right and none intersect it. There should be no red.
-    </p>
     <div id="test">
         <div id="shape-box"></div>
         <img src="support/rounded-triangle.svg">

--- a/css-shapes-1/spec-examples/shape-outside-019.html
+++ b/css-shapes-1/spec-examples/shape-outside-019.html
@@ -15,6 +15,7 @@
         #test {
             position: relative;
             color: green;
+            visibility: hidden;
             width: 400px;
             font-family: Ahem;
             font-size: 20px;
@@ -41,11 +42,6 @@
     <script src="support/spec-example-utils.js"></script>
 </head>
 <body>
-    <p>
-        The test passes if the short green horizontal bars are the right of the black edge
-        of circle, the long green bar is beneath it, and no bars intersect the black.
-        There should be no red.
-    </p>
     <div id="test">
         <img id="image" src="support/circle-shadow.png"/>
         <div id="margin-circle"></div>


### PR DESCRIPTION
Blink's test scripts only accept a testharness.js test as passing if
the only lines of text output from the test are output from
testharness.js itself. So this hides the visual part of the test and
only displays the testharness output to make these tests fully
compatible with running in Blink.
