### PR TITLE
[css-grid] first-line does not apply to grid containers

### DIFF
--- a/css-grid-1/grid-model/grid-first-line-001.xht
+++ b/css-grid-1/grid-model/grid-first-line-001.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' from grid container does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element is ignored in grid items when applied to a grid container." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+                color: green;
+            }
+
+            .grid::first-line {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-first-line-002.xht
+++ b/css-grid-1/grid-model/grid-first-line-002.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' from grid container ancestors does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element is ignored in grid items when applied to a grid container ancestors." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+                color: green;
+            }
+
+            body::first-line {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-first-line-003.xht
+++ b/css-grid-1/grid-model/grid-first-line-003.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' works on grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element works as expected if it is applied directly to a grid item." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+                color: red;
+            }
+
+            .item::first-line {
+                color: green;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div class="item">
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-line-001.xht
+++ b/css-grid-1/grid-model/grid-inline-first-line-001.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' from inline grid container does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element is ignored in grid items when applied to an inline grid container." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+                color: green;
+            }
+
+            .inline-grid::first-line {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-line-002.xht
+++ b/css-grid-1/grid-model/grid-inline-first-line-002.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' from inline grid container ancestors does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element is ignored in anonymous grid items when applied to an inline grid container ancestors." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+                color: green;
+            }
+
+            body::first-line {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-line-003.xht
+++ b/css-grid-1/grid-model/grid-inline-first-line-003.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-line' works on grid items within an inline grid</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-formatted-line" title="7.1.1. First formatted line definition in CSS" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-line' pseudo-element works as expected if it is applied directly to a grid item within an inline grid." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+                color: red;
+            }
+
+            .item::first-line {
+                color: green;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div class="item">
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This pull request is part of issue #632 (a similar approach should be followed to test `::first-letter`).