### PR TITLE
Update background-001-ref.xht reftest

### DIFF
--- a/css21/backgrounds/background-001-ref.xht
+++ b/css21/backgrounds/background-001-ref.xht
@@ -8,13 +8,21 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
+  <style type="text/css">
+  div 
+  {
+  background: url(support/60x60-green.png);
+  height: 50px;
+  }
+  </style>
+
  </head>
 
  <body>
 
   <p>Test passes if there is a filled green rectangle across the page.</p>
 
-  <div><img src="support/1x1-green.png" width="100%" height="50" alt="Image download support must be enabled" /></div>
+  <div></div>
 
  </body>
 </html>


### PR DESCRIPTION
- Because the background picture used before in reftest file is inconsistent with origin test color.