### PR TITLE
[css-grid] first-letter does not apply to grid containers

### DIFF
--- a/css-grid-1/grid-model/grid-first-letter-001.xht
+++ b/css-grid-1/grid-model/grid-first-letter-001.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' from grid container does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element is ignored in grid items when applied to a grid container." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+                color: green;
+            }
+
+            .grid::first-letter {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-first-letter-002.xht
+++ b/css-grid-1/grid-model/grid-first-letter-002.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' from grid container ancestors does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element is ignored in grid items when applied to a grid container ancestors." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+                color: green;
+            }
+
+            body::first-letter {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-first-letter-003.xht
+++ b/css-grid-1/grid-model/grid-first-letter-003.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' works on grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-first-letter-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element works as expected if it is applied directly to a grid item." />
+        <style type="text/css"><![CDATA[
+            .grid {
+                display: grid;
+            }
+
+            .item::first-letter {
+                color: green;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="grid">
+            <div class="item">
+                <p>
+                    The <strong>first letter</strong> of this paragraph, and only that one, should be <strong>green</strong>.
+                    In addition, body and paragraph margins should <strong>not collapse</strong>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-letter-001.xht
+++ b/css-grid-1/grid-model/grid-inline-first-letter-001.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' from inline grid container does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element is ignored in grid items when applied to an inline grid container." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+                color: green;
+            }
+
+            .grid::first-letter {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-letter-002.xht
+++ b/css-grid-1/grid-model/grid-inline-first-letter-002.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' from inline grid container ancestors does not apply to grid items</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-text-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element is ignored in grid items when applied to an inline grid container ancestors." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+                color: green;
+            }
+
+            body::first-letter {
+                color: red;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div>
+                <p>This text should be <strong>green</strong> and body and paragraph margins should <strong>not collapse</strong>.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-model/grid-inline-first-letter-003.xht
+++ b/css-grid-1/grid-model/grid-inline-first-letter-003.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: '::first-letter' works on grid items within an inline grid</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-selectors/#first-letter" title="7.2. The ::first-letter pseudo-element" />
+        <link rel="match" href="../reference/grid-first-letter-green-margin-no-collapse-ref.xht" />
+        <meta name="assert" content="This test checks that '::first-letter' pseudo-element works as expected if it is applied directly to a grid item within an inline grid." />
+        <style type="text/css"><![CDATA[
+            .inline-grid {
+                display: inline-grid;
+            }
+
+            .item::first-letter {
+                color: green;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <div class="inline-grid">
+            <div class="item">
+                <p>
+                    The <strong>first letter</strong> of this paragraph, and only that one, should be <strong>green</strong>.
+                    In addition, body and paragraph margins should <strong>not collapse</strong>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/reference/grid-first-letter-green-margin-no-collapse-ref.xht
+++ b/css-grid-1/reference/grid-first-letter-green-margin-no-collapse-ref.xht
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: Reference file text first letter should be green and margins do not collapse</title>
+        <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
+        <style type="text/css"><![CDATA[
+            p {
+                /* Prevent collapsing body and paragraph margins. */
+                float: left;
+            }
+
+            .green {
+                color: green;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <p>
+            <span class="green">T</span>he <strong>first letter</strong> of this paragraph, and only that one, should be <strong>green</strong>.
+            In addition, body and paragraph margins should <strong>not collapse</strong>.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
This pull request is part of issue #632. It just mimics the tests for `::first-line` done in #699.