### PR TITLE
Writing Modes: use smaller fonts for text-combine-upright tests

### DIFF
--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
@@ -7,14 +7,14 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>x</p>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x1-notref.html
@@ -7,7 +7,7 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
@@ -7,14 +7,14 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x3-notref.html
@@ -7,7 +7,7 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
@@ -7,14 +7,14 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x4-notref.html
@@ -7,7 +7,7 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
@@ -7,7 +7,7 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/horizontal-ahem-1x5-notref.html
@@ -7,14 +7,14 @@
 <meta name="flags" content="ahem">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxxxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
@@ -9,14 +9,14 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>x</p>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x1-ref.html
@@ -9,7 +9,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
@@ -9,14 +9,14 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x3-ref.html
@@ -9,7 +9,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
@@ -9,7 +9,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x4-ref.html
@@ -9,14 +9,14 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
@@ -9,14 +9,14 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p>xxxxx</p>

--- a/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/vertical-ahem-1x5-ref.html
@@ -9,7 +9,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001l-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001l-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
 }
 </style>
 </head>

--- a/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001l-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001l-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
 }
 </style>
 </head>

--- a/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001r-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001r-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
 <style>
 .test {
-  font-size: 80px;
+  font-size: 5em;
   direction: rtl;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001r-ref.html
+++ b/css-writing-modes-3/text-combine-upright/reference/writing-mode-horizontal-001r-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Masataka Yakura" href="http://google.com/+MasatakaYakura">
 <style>
 .test {
-  font-size: 100px;
+  font-size: 80px;
   direction: rtl;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright/value-all-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">ABC</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-all-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-all-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">ABCDE</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-all-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-all-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits2-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">12</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits2-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits2-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">123</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits2-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits2-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits3-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">12</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits3-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">123</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits3-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">1234</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits3-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits3-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits4-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">123</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits4-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits4-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if there are two squares:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">1234</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits4-002.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-002.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-digits4-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">12345</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-digits4-003.html
+++ b/css-writing-modes-3/text-combine-upright/value-digits4-003.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/value-none-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-none-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 100px;
+  font-size: 80px;
   font-family: Ahem;
 }
 
@@ -23,7 +23,7 @@
 </head>
 <body>
 
-<p>Test passes if the following rectangles are identical:</p>
+<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
 
 <div class="test">
   <p><span class="tcy">A01</span></p>

--- a/css-writing-modes-3/text-combine-upright/value-none-001.html
+++ b/css-writing-modes-3/text-combine-upright/value-none-001.html
@@ -12,7 +12,7 @@
 <style>
 .test {
   writing-mode: vertical-rl;
-  font-size: 80px;
+  font-size: 5em;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001l.html
+++ b/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001l.html
@@ -10,7 +10,7 @@
 <style>
 .test {
   writing-mode: horizontal-tb;
-  font-size: 100px;
+  font-size: 80px;
 }
 
 .tcy {

--- a/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001l.html
+++ b/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001l.html
@@ -10,7 +10,7 @@
 <style>
 .test {
   writing-mode: horizontal-tb;
-  font-size: 80px;
+  font-size: 5em;
 }
 
 .tcy {

--- a/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001r.html
+++ b/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001r.html
@@ -10,7 +10,7 @@
 <style>
 .test {
   writing-mode: horizontal-tb;
-  font-size: 80px;
+  font-size: 5em;
   direction: rtl;
 }
 

--- a/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001r.html
+++ b/css-writing-modes-3/text-combine-upright/writing-mode-horizontal-001r.html
@@ -10,7 +10,7 @@
 <style>
 .test {
   writing-mode: horizontal-tb;
-  font-size: 100px;
+  font-size: 80px;
   direction: rtl;
 }
 


### PR DESCRIPTION
I've used 100px for font-size in my TCU tests; however, gtalbot's told me that
may overflow on UAs that support vertical writing modes but logical properties.

http://lists.w3.org/Archives/Public/public-css-testsuite/2015Feb/0028.html

Per his advice, update font-size to 80px so that tests fit in 800x600 dims.