### PR TITLE
R12a/word break

### DIFF
--- a/css-text-3/word-break/ref/word-break-break-all-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, japanese</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-001.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-001.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, latin</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Latin latin latin lati<br/>n</span></div>
+<div class="ref"><span>Latin latin latin lati<br/>n</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-002.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, korean</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-003.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-003.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, thai</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษาไท<br/>ย</span></div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษาไท<br/>ย</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-004.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-004.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, arabic</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" dir="rtl" lang="ar"><span>التدويل نشاط التدوي&#x200D;<br/>&#x200D;ل</span></div>
+<div class="ref" dir="rtl" lang="ar"><span>التدويل نشاط التدوي&#x200D;<br/>&#x200D;ل</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-005.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-005.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, subjoined tibetan</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="bo"><span>ལྷ་སའི་སྐད་ད་<br/>ལྟ</span></div>
+<div class="ref" lang="bo"><span>ལྷ་སའི་སྐད་ད་<br/>ལྟ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-006.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-006.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, spacing vowel sign</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिं<br/>दी</span></div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिं<br/>दी</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-007.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-007.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, combining diacritic</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာမြ<br/>န်</span></div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာမြ<br/>န်</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-break-all-ref-008.html
+++ b/css-text-3/word-break/ref/word-break-break-all-ref-008.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, syllabic cluster</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="hi"><span>हिन्दी हिन्दी हि<br/>न्दी</span></div>
+<div class="ref" lang="hi"><span>हिन्दी हिन्दी हि<br/>न्दी</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-keep-all-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-keep-all-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, latin</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-keep-all-ref-001.html
+++ b/css-text-3/word-break/ref/word-break-keep-all-ref-001.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, japanese</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>日本語 日本語<br/>日本語</span></div>
+<div class="ref" lang="ja"><span>日本語 日本語<br/>日本語</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-keep-all-ref-002.html
+++ b/css-text-3/word-break/ref/word-break-keep-all-ref-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, korean</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ko"><span>한글이 한글이<br/>한글이</span></div>
+<div class="ref" lang="ko"><span>한글이 한글이<br/>한글이</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-keep-all-ref-003.html
+++ b/css-text-3/word-break/ref/word-break-keep-all-ref-003.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, thai</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
+<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ar-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-ar-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, arabic</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ar" dir="rtl"><span>العَرَبِيةُ العَرَبِيةُ<br/>العَرَبِيةُ</span></div>
+<div class="ref" lang="ar" dir="rtl"><span>العَرَبِيةُ العَرَبِيةُ<br/>العَرَبِيةُ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-bo-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-bo-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, tibetan</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.4 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="tdd"><span>ལྷ་སའི་སྐད་ལྷ་སའི་<br/>སྐད་</span></div>
+<div class="ref" lang="tdd"><span>ལྷ་སའི་སྐད་ལྷ་སའི་<br/>སྐད་</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-en-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-en-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, latin</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-hi-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-hi-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, hindi</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.4 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिंदी<br/>हिंदी</span></div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिंदी<br/>हिंदी</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ja-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-ja-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ja-ref-001.html
+++ b/css-text-3/word-break/ref/word-break-normal-ja-ref-001.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese hiragana</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>にほんごにほん<br/>ご</span></div>
+<div class="ref" lang="ja"><span>にほんごにほん<br/>ご</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ja-ref-002.html
+++ b/css-text-3/word-break/ref/word-break-normal-ja-ref-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese katakana</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>ニホンゴニホン<br/>ゴ</span></div>
+<div class="ref" lang="ja"><span>ニホンゴニホン<br/>ゴ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ja-ref-004.html
+++ b/css-text-3/word-break/ref/word-break-normal-ja-ref-004.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語。</span></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語。</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-km-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-km-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, khmer</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="km"><span>ភាសាខ្មែរភាសាខ្មែរ<br/>ភាសាខ្មែរ</span></div>
+<div class="ref" lang="km"><span>ភាសាខ្មែរភាសាខ្មែរ<br/>ភាសាខ្មែរ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ko-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-ko-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, korean</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-lo-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-lo-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, lao</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="lo"><span>ພາສາລາວພາສາລາວພາສາ<br/>ລາວ</span></div>
+<div class="ref" lang="lo"><span>ພາສາລາວພາສາລາວພາສາ<br/>ລາວ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-my-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-my-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, myanmar</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာ<br/>မြန်မာစာ</span></div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာ<br/>မြန်မာစာ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-ref-001.html
+++ b/css-text-3/word-break/ref/word-break-normal-ref-001.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, zwsp</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="en"><span>latinlatinlatin<br/>latin</span></div>
+<div class="ref" lang="en"><span>latinlatinlatin<br/>latin</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-tdd-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-tdd-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, tai nüa</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="tdd"><span>ᥖᥭᥰᥖᥬᥳ<br/>ᥑᥨᥒᥰ</span></div>
+<div class="ref" lang="tdd"><span>ᥖᥭᥰᥖᥬᥳ<br/>ᥑᥨᥒᥰ</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-th-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-th-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, thai</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษา<br/>ไทย</span></div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษา<br/>ไทย</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/ref/word-break-normal-zh-ref-000.html
+++ b/css-text-3/word-break/ref/word-break-normal-zh-ref-000.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, chinese</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref" lang="zh"><span>中國話中國話中國<br/>語</span></div>
+<div class="ref" lang="zh"><span>中國話中國話中國<br/>語</span></div>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-000.html
+++ b/css-text-3/word-break/word-break-break-all-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, japanese</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">日本語日本語日本語</span></div></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-001.html
+++ b/css-text-3/word-break/word-break-break-all-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, latin</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-001.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Latin latin latin latin</span></div></div>
+<div class="ref"><span>Latin latin latin lati<br/>n</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-002.html
+++ b/css-text-3/word-break/word-break-break-all-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, korean</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-002.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ko"><div id="testdiv"><span id="testspan">한글이 한글이 한글이</span></div></div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-003.html
+++ b/css-text-3/word-break/word-break-break-all-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, thai</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-003.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="th"><div id="testdiv"><span id="testspan">ภาษาไทยภาษาไทย</span></div></div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษาไท<br/>ย</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-004.html
+++ b/css-text-3/word-break/word-break-break-all-004.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, arabic</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units. When shaping scripts such as Arabic are allowed to break within words due to break-all, the characters must still be shaped as if the word were not broken.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-004.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" dir="rtl" lang="ar"><div id="testdiv"><span id="testspan">التدويل نشاط التدويل</span></div></div>
+<div class="ref" dir="rtl" lang="ar"><span>التدويل نشاط التدوي&#x200D;<br/>&#x200D;ل</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-005.html
+++ b/css-text-3/word-break/word-break-break-all-005.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, subjoined tibetan</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-005.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="bo"><div id="testdiv"><span id="testspan">ལྷ་སའི་སྐད་ད་ལྟ</span></div></div>
+<div class="ref" lang="bo"><span>ལྷ་སའི་སྐད་ད་<br/>ལྟ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-006.html
+++ b/css-text-3/word-break/word-break-break-all-006.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, spacing vowel sign</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units. A spacing vowel sign should be wrapped to the next line with its base character.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-006.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="hi"><div id="testdiv"><span id="testspan">हिंदी हिंदी हिंदी</span></div></div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिं<br/>दी</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+<!--
+Notes:
+A typographic unit based on extended grapheme clusters groups base characters and combining characters together.
+-->
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-007.html
+++ b/css-text-3/word-break/word-break-break-all-007.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, combining diacritic</title>
+<meta name="assert" content="word-break: break-all means lines may break between any two typographic letter units. An combining diacritic plus base character should be wrapped as a unit to the next line.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-007.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="my"><div id="testdiv"><span id="testspan">မြန်မာစာမြန်မာစာမြန်</span></div></div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာမြ<br/>န်</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+<!--
+Notes:
+A typographic unit based on extended grapheme clusters groups base characters and combining characters together.
+-->
+</body>
+</html>

--- a/css-text-3/word-break/word-break-break-all-008.html
+++ b/css-text-3/word-break/word-break-break-all-008.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: break-all, syllabic cluster</title>
+<meta name="assert" content="[Exploratory test] word-break: break-all means lines may break between any two typographic letter units. An indic syllable cluster should be wrapped as a unit to the next line.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-break-all-ref-008.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: break-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.5 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="hi"><div id="testdiv"><span id="testspan">हिन्दी हिन्दी हिन्दी</span></div></div>
+<div class="ref" lang="hi"><span>हिन्दी हिन्दी हि<br/>न्दी</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+<!--
+Notes:
+This test is exploratory because indic conjuncts containing more than one consonant are not covered by the extended grapheme cluster definition, and therefore constitute more than one typographic unit, as defined in the CSS spec. Nevertheless, people using indic scripts expect the user agent to keep the orthographic syllable as a single unit.
+-->
+</body>
+</html>

--- a/css-text-3/word-break/word-break-keep-all-000.html
+++ b/css-text-3/word-break/word-break-keep-all-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, latin</title>
+<meta name="assert" content="word-break: keep-all means breaking is forbidden within 'words'.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-keep-all-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Latin latin latin latin</span></div></div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-keep-all-001.html
+++ b/css-text-3/word-break/word-break-keep-all-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, japanese</title>
+<meta name="assert" content="word-break: keep-all means breaking is forbidden within 'words'.  In this style, sequences of CJK characters do not break.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-keep-all-ref-001.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">日本語 日本語 日本語</span></div></div>
+<div class="ref" lang="ja"><span>日本語 日本語<br/>日本語</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-keep-all-002.html
+++ b/css-text-3/word-break/word-break-keep-all-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, korean</title>
+<meta name="assert" content="word-break: keep-all means breaking is forbidden within 'words'.  In this style, sequences of CJK characters do not break.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-keep-all-ref-002.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ko"><div id="testdiv"><span id="testspan">한글이 한글이 한글이</span></div></div>
+<div class="ref" lang="ko"><span>한글이 한글이<br/>한글이</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-keep-all-003.html
+++ b/css-text-3/word-break/word-break-keep-all-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: keep-all, thai</title>
+<meta name="assert" content="word-break: keep-all means breaking is forbidden within 'words',  except where opportunities exist due to dictionary-based breaking (such as in Thai).">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-keep-all-ref-003.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="th"><div id="testdiv"><span id="testspan">แและ แและแและ</span></div></div>
+<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-001.html
+++ b/css-text-3/word-break/word-break-normal-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, zwsp</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules. A ZWSP character should provide a break point.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ref-001.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="en"><div id="testdiv"><span id="testspan">latinlatinlatin&#x200B;latin</span></div></div>
+<div class="ref" lang="en"><span>latinlatinlatin<br/>latin</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ar-000.html
+++ b/css-text-3/word-break/word-break-normal-ar-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, arabic</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ar-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ar" dir="rtl"><div id="testdiv"><span id="testspan">العَرَبِيةُ العَرَبِيةُ العَرَبِيةُ</span></div></div>
+<div class="ref" lang="ar" dir="rtl"><span>العَرَبِيةُ العَرَبِيةُ<br/>العَرَبِيةُ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-bo-000.html
+++ b/css-text-3/word-break/word-break-normal-bo-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, tibetan</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-bo-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.4 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="tdd"><div id="testdiv"><span id="testspan">ལྷ་སའི་སྐད་ལྷ་སའི་སྐད་</span></div></div>
+<div class="ref" lang="tdd"><span>ལྷ་སའི་སྐད་ལྷ་སའི་<br/>སྐད་</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-en-000.html
+++ b/css-text-3/word-break/word-break-normal-en-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, latin</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-en-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Latin latin latin latin</span></div></div>
+<div class="ref"><span>Latin latin latin<br/>latin</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-hi-000.html
+++ b/css-text-3/word-break/word-break-normal-hi-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, hindi</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-hi-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1.4 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="hi"><div id="testdiv"><span id="testspan">हिंदी हिंदी हिंदी हिंदी</span></div></div>
+<div class="ref" lang="hi"><span>हिंदी हिंदी हिंदी<br/>हिंदी</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ja-000.html
+++ b/css-text-3/word-break/word-break-normal-ja-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ja-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">日本語日本語日本語</span></div></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ja-001.html
+++ b/css-text-3/word-break/word-break-normal-ja-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese hiragana</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ja-ref-001.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">にほんごにほんご</span></div></div>
+<div class="ref" lang="ja"><span>にほんごにほん<br/>ご</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ja-002.html
+++ b/css-text-3/word-break/word-break-normal-ja-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese katakana</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ja-ref-002.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">ニホンゴニホンゴ</span></div></div>
+<div class="ref" lang="ja"><span>ニホンゴニホン<br/>ゴ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ja-004.html
+++ b/css-text-3/word-break/word-break-normal-ja-004.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, japanese</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ja-ref-004.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ja"><div id="testdiv"><span id="testspan">日本語日本語日本語。</span></div></div>
+<div class="ref" lang="ja"><span>日本語日本語日本<br/>語。</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-km-000.html
+++ b/css-text-3/word-break/word-break-normal-km-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, khmer</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-km-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="km"><div id="testdiv"><span id="testspan">ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ</span></div></div>
+<div class="ref" lang="km"><span>ភាសាខ្មែរភាសាខ្មែរ<br/>ភាសាខ្មែរ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-ko-000.html
+++ b/css-text-3/word-break/word-break-normal-ko-000.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, korean</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules. Korean, which commonly exhibits two different behaviors, allows breaks between any two consecutive Hangul/Hanja.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-ko-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="ko"><div id="testdiv"><span id="testspan">한글이 한글이 한글이</span></div></div>
+<div class="ref" lang="ko"><span>한글이 한글이 한글<br/>이</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+<!--
+Notes:
+It is possible to break Korean at character or word boundaries, depending on author preference. Breaking at character boundaries tends to be more common in modern Korean text, so that has been chosen as the reference here.  If the word breaks at word boundaries, that is not necessarily an error, but it is not what the spec describes for word-break: normal.
+-->
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-lo-000.html
+++ b/css-text-3/word-break/word-break-normal-lo-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, lao</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-lo-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="lo"><div id="testdiv"><span id="testspan">ພາສາລາວພາສາລາວພາສາລາວ</span></div></div>
+<div class="ref" lang="lo"><span>ພາສາລາວພາສາລາວພາສາ<br/>ລາວ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-my-000.html
+++ b/css-text-3/word-break/word-break-normal-my-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, myanmar</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-my-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="my"><div id="testdiv"><span id="testspan">မြန်မာစာမြန်မာစာမြန်မာစာ</span></div></div>
+<div class="ref" lang="my"><span>မြန်မာစာမြန်မာစာ<br/>မြန်မာစာ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-tdd-000.html
+++ b/css-text-3/word-break/word-break-normal-tdd-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, tai nüa</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-tdd-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="tdd"><div id="testdiv"><span id="testspan">ᥖᥭᥰᥖᥬᥳᥑᥨᥒᥰ</span></div></div>
+<div class="ref" lang="tdd"><span>ᥖᥭᥰᥖᥬᥳ<br/>ᥑᥨᥒᥰ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-th-000.html
+++ b/css-text-3/word-break/word-break-normal-th-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, thai</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-th-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="th"><div id="testdiv"><span id="testspan">ภาษาไทยภาษาไทย</span></div></div>
+<div class="ref" lang="th"><span>ภาษาไทยภาษา<br/>ไทย</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>

--- a/css-text-3/word-break/word-break-normal-zh-000.html
+++ b/css-text-3/word-break/word-break-normal-zh-000.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>word-break: normal, chinese</title>
+<meta name="assert" content="word-break: normal means words break according to their customary rules.">
+<link rel='help' href='http://dev.w3.org/csswg/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-normal-zh-ref-000.html'>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<style type='text/css'>
+.test { word-break: normal; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test" lang="zh"><div id="testdiv"><span id="testspan">中國話中國話中國話</span></div></div>
+<div class="ref" lang="zh"><span>中國話中國話中國<br/>語</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').offsetWidth
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+</body>
+</html>


### PR DESCRIPTION
New tests and ref test files for css-text-3 word-break.
There is one exploratory test (marked as such in the assertion).
Tests for word-break: normal test a limited number of scripts for word-break behaviours that are clearly appropriate, even though  the spec has the vague wording "words break according to their customary rules".