### PR TITLE
Fix flex-margin-no-collapse.html

### DIFF
--- a/css-flexbox-1/flex-margin-no-collapse.html
+++ b/css-flexbox-1/flex-margin-no-collapse.html
@@ -22,6 +22,7 @@
 			width: 100px;
 			height: 100px;
 			background-color: green;
+			flex: none;
 		}
 
 		#box1 {


### PR DESCRIPTION
As described in https://lists.w3.org/Archives/Public/www-style/2015Mar/0463.html, the testcase is broken. This patch adds flex:none so that it displays correctly; this seems to match the intention better than the alternative of changing the container's height to 400px. Without this change, the boxes will shrink due to the flexing and not cover up the red box.
