### PR TITLE
Fix ttwf-reftest-flex-inline-ref.html

### DIFF
--- a/css-flexbox-1/reference/ttwf-reftest-flex-inline-ref.html
+++ b/css-flexbox-1/reference/ttwf-reftest-flex-inline-ref.html
@@ -17,8 +17,7 @@
     </style>
 </head>
 <body>
-    <p>The test passed if you see a green block which its text is 'Success!
-'.</p>
+    <p>The test passed if you see a green block which its text is 'Success!'.</p>
     <div class="container">
       <!-- This is the square that should not be visible if the test passes -->
       <div class="greenSquare">Success!</div>


### PR DESCRIPTION
There is a linebreak here that shouldn't exist, because it does not exist in the test file. This makes the test fail.
