### PR TITLE
[css-flexbox] Fix ttwf-reftest-flex-direction-row-reverse-ref.html

### DIFF
--- a/css-flexbox-1/reference/ttwf-reftest-flex-direction-row-reverse-ref.html
+++ b/css-flexbox-1/reference/ttwf-reftest-flex-direction-row-reverse-ref.html
@@ -7,7 +7,6 @@
         .container {
 	position: relative;
 	display: flex;
-	flex-direction: row-reverse;
 	background: red;
 	margin: 1em 0;
 	border: 1px solid black;


### PR DESCRIPTION
The reference should not have the row-reverse style, because then it double-reverses the order of the flex items and the test fails.
