### PR TITLE
[css-page] Improve page-container-010

### DIFF
--- a/css21/page-box/page-container-010.xht
+++ b/css21/page-box/page-container-010.xht
@@ -18,17 +18,17 @@ html, body {
 }
 div {
     height: 50%;
-    border-bottom: medium red solid;
+    border-bottom: 10px red solid;
 }
 .test {
     position: absolute;
-    top: 49.5%;
-    bottom: 49.5%;
+    top: 50%;
+    bottom: auto;
     right: 0;
     left: 0;
     background: blue;
     border: 0;
-    height: auto;
+    height: 10px;
 }
 p {
     margin-top: 0;


### PR DESCRIPTION
The original test occasionally fails depending on the page area height since the height of the `.test` box is specified in percentage (difference between `top` and `bottom`) while the border width is `medium`.
The problem can be solved by specifying both of the height and the border width in terms of an absolute length (`10px`).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/778)

<!-- Reviewable:end -->
