### PR TITLE
[css-text-3] TC for making sure break-word also breaks &nbsp;

### DIFF
--- a/css-text-3/overflow-wrap-break-word-001.html
+++ b/css-text-3/overflow-wrap-break-word-001.html
@@ -5,7 +5,7 @@
 <link rel="help" href="http://dev.w3.org/csswg/css-text-3/#valdef-overflow-wrap-break-word">
 <meta name="flags" content="ahem">
 <link rel="match" href="reftest/overflow-wrap-break-word-001-ref.html">
-<meta name="assert" content="An otherwise unbreakable sequence of characters may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.">
+<meta name="assert" content="sequences of nbsp characters that would cause overflow are expected to be broken when overflow-wrap is break-word">
 <style>
 div {
 	position: relative;

--- a/css-text-3/overflow-wrap-break-word-001.html
+++ b/css-text-3/overflow-wrap-break-word-001.html
@@ -8,20 +8,20 @@
 <meta name="assert" content="sequences of nbsp characters that would cause overflow are expected to be broken when overflow-wrap is break-word">
 <style>
 div {
-	position: relative;
-	width: 100px;
-	height: 100px;
-	font-family: ahem;
-	color: red;
-	overflow-wrap: break-word;
-	font-size: 25px;
-	line-height: 27px;
+  position: relative;
+  width: 100px;
+  height: 100px;
+  font-family: ahem;
+  color: red;
+  overflow-wrap: break-word;
+  font-size: 25px;
+  line-height: 27px;
 }
 div::after{
-	content: "";
-	position: absolute;
-	top: 0; left: 0; bottom: 0; right: 0;
-	background: green;
+  content: "";
+  position: absolute;
+  top: 0; left: 0; bottom: 0; right: 0;
+  background: green;
 }
 </style>
 <body>

--- a/css-text-3/overflow-wrap-break-word-001.html
+++ b/css-text-3/overflow-wrap-break-word-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="http://dev.w3.org/csswg/css-text-3/#valdef-overflow-wrap-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="reftest/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="An otherwise unbreakable sequence of characters may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.">
+<style>
+div {
+	position: relative;
+	width: 100px;
+	height: 100px;
+	font-family: ahem;
+	color: red;
+	overflow-wrap: break-word;
+	font-size: 25px;
+	line-height: 27px;
+}
+div::after{
+	content: "";
+	position: absolute;
+	top: 0; left: 0; bottom: 0; right: 0;
+	background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X</div>
+</body>

--- a/css-text-3/reftest/overflow-wrap-break-word-001-ref.html
+++ b/css-text-3/reftest/overflow-wrap-break-word-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Reference File</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+	position: relative;
+	width: 100px;
+	height: 100px;
+	background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div></div>
+</body>

--- a/css-text-3/reftest/overflow-wrap-break-word-001-ref.html
+++ b/css-text-3/reftest/overflow-wrap-break-word-001-ref.html
@@ -4,10 +4,10 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <style>
 div {
-	position: relative;
-	width: 100px;
-	height: 100px;
-	background: green;
+  position: relative;
+  width: 100px;
+  height: 100px;
+  background: green;
 }
 </style>
 <body>


### PR DESCRIPTION
To be merged if we resolve in favor of https://lists.w3.org/Archives/Public/www-style/2015Jun/0100.html
(and if the test looks sane, of course).