### PR TITLE
[css-grid] Add new cases for grid-template-areas with dots sequences

### DIFF
--- a/css-grid-1/grid-definition/grid-inline-support-grid-template-areas-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-grid-template-areas-001.xht
@@ -35,12 +35,22 @@
             TestingUtils.testGridTemplateAreas('inline-grid', '"a b" "a b"', '"a b" "a b"');
             TestingUtils.testGridTemplateAreas('inline-grid', '"a a" "b b"', '"a a" "b b"');
             TestingUtils.testGridTemplateAreas('inline-grid', '". a ." "b a c"', '". a ." "b a c"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '".. a ..." "b a c"', '". a ." "b a c"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '".a..." "b a c"', '". a ." "b a c"');
             TestingUtils.testGridTemplateAreas('inline-grid', '"head head" "nav main" "foot ."', '"head head" "nav main" "foot ."');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"head head" "nav main" "foot ...."', '"head head" "nav main" "foot ."');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"head head" "nav main" "foot."', '"head head" "nav main" "foot ."');
             TestingUtils.testGridTemplateAreas('inline-grid', '". header header ." "nav main main main" "nav footer footer ."', '". header header ." "nav main main main" "nav footer footer ."');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"... header header ...." "nav main main main" "nav footer footer ...."', '". header header ." "nav main main main" "nav footer footer ."');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"...header header...." "nav main main main" "nav footer footer...."', '". header header ." "nav main main main" "nav footer footer ."');
             TestingUtils.testGridTemplateAreas('inline-grid', '"title stats" "score stats" "board board" "ctrls ctrls"', '"title stats" "score stats" "board board" "ctrls ctrls"');
             TestingUtils.testGridTemplateAreas('inline-grid', '"title board" "stats board" "score ctrls"', '"title board" "stats board" "score ctrls"');
             TestingUtils.testGridTemplateAreas('inline-grid', '". a" "b a" ". a"', '". a" "b a" ". a"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '".. a" "b a" "... a"', '". a" "b a" ". a"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"..a" "b a" ".a"', '". a" "b a" ". a"');
             TestingUtils.testGridTemplateAreas('inline-grid', '"a a a" "b b b"', '"a a a" "b b b"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '". ." "a a"', '". ." "a a"');
+            TestingUtils.testGridTemplateAreas('inline-grid', '"... ...." "a a"', '". ." "a a"');
 
             // Reset values.
             document.getElementById('inline-grid').style.gridTemplateAreas = '';

--- a/css-grid-1/grid-definition/grid-support-grid-template-areas-001.xht
+++ b/css-grid-1/grid-definition/grid-support-grid-template-areas-001.xht
@@ -35,12 +35,22 @@
             TestingUtils.testGridTemplateAreas('grid', '"a b" "a b"', '"a b" "a b"');
             TestingUtils.testGridTemplateAreas('grid', '"a a" "b b"', '"a a" "b b"');
             TestingUtils.testGridTemplateAreas('grid', '". a ." "b a c"', '". a ." "b a c"');
+            TestingUtils.testGridTemplateAreas('grid', '".. a ..." "b a c"', '". a ." "b a c"');
+            TestingUtils.testGridTemplateAreas('grid', '".a..." "b a c"', '". a ." "b a c"');
             TestingUtils.testGridTemplateAreas('grid', '"head head" "nav main" "foot ."', '"head head" "nav main" "foot ."');
+            TestingUtils.testGridTemplateAreas('grid', '"head head" "nav main" "foot ...."', '"head head" "nav main" "foot ."');
+            TestingUtils.testGridTemplateAreas('grid', '"head head" "nav main" "foot."', '"head head" "nav main" "foot ."');
             TestingUtils.testGridTemplateAreas('grid', '". header header ." "nav main main main" "nav footer footer ."', '". header header ." "nav main main main" "nav footer footer ."');
+            TestingUtils.testGridTemplateAreas('grid', '"... header header ...." "nav main main main" "nav footer footer ...."', '". header header ." "nav main main main" "nav footer footer ."');
+            TestingUtils.testGridTemplateAreas('grid', '"...header header...." "nav main main main" "nav footer footer...."', '". header header ." "nav main main main" "nav footer footer ."');
             TestingUtils.testGridTemplateAreas('grid', '"title stats" "score stats" "board board" "ctrls ctrls"', '"title stats" "score stats" "board board" "ctrls ctrls"');
             TestingUtils.testGridTemplateAreas('grid', '"title board" "stats board" "score ctrls"', '"title board" "stats board" "score ctrls"');
             TestingUtils.testGridTemplateAreas('grid', '". a" "b a" ". a"', '". a" "b a" ". a"');
+            TestingUtils.testGridTemplateAreas('grid', '".. a" "b a" "... a"', '". a" "b a" ". a"');
+            TestingUtils.testGridTemplateAreas('grid', '"..a" "b a" ".a"', '". a" "b a" ". a"');
             TestingUtils.testGridTemplateAreas('grid', '"a a a" "b b b"', '"a a a" "b b b"');
+            TestingUtils.testGridTemplateAreas('grid', '". ." "a a"', '". ." "a a"');
+            TestingUtils.testGridTemplateAreas('grid', '"... ...." "a a"', '". ." "a a"');
 
             // Reset values.
             document.getElementById('grid').style.gridTemplateAreas = '';


### PR DESCRIPTION
grid-template-areas can have now dot sequences to represent unnamed areas, added new test cases on the related tests.

Also, the space between named and unnamed areas is not mandatory. Added new cases as this was not being checked before.

This is an update for issue #649.