### PR TITLE
update text-combine-upright tests using Ahem to set line-height explicitly

### DIFF
--- a/css-writing-modes-3/reference/horizontal-ahem-1x1-notref.html
+++ b/css-writing-modes-3/reference/horizontal-ahem-1x1-notref.html
@@ -8,13 +8,14 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p>x</p>

--- a/css-writing-modes-3/reference/horizontal-ahem-1x3-notref.html
+++ b/css-writing-modes-3/reference/horizontal-ahem-1x3-notref.html
@@ -8,6 +8,7 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/horizontal-ahem-1x4-notref.html
+++ b/css-writing-modes-3/reference/horizontal-ahem-1x4-notref.html
@@ -8,6 +8,7 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/horizontal-ahem-1x5-notref.html
+++ b/css-writing-modes-3/reference/horizontal-ahem-1x5-notref.html
@@ -8,6 +8,7 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/vertical-ahem-1x1-ref.html
+++ b/css-writing-modes-3/reference/vertical-ahem-1x1-ref.html
@@ -9,13 +9,14 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p>x</p>

--- a/css-writing-modes-3/reference/vertical-ahem-1x3-ref.html
+++ b/css-writing-modes-3/reference/vertical-ahem-1x3-ref.html
@@ -9,6 +9,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/vertical-ahem-1x4-ref.html
+++ b/css-writing-modes-3/reference/vertical-ahem-1x4-ref.html
@@ -9,6 +9,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/vertical-ahem-1x5-ref.html
+++ b/css-writing-modes-3/reference/vertical-ahem-1x5-ref.html
@@ -9,6 +9,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 </style>

--- a/css-writing-modes-3/reference/writing-mode-horizontal-001l-ref.html
+++ b/css-writing-modes-3/reference/writing-mode-horizontal-001l-ref.html
@@ -7,6 +7,7 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
 }
 </style>
 </head>

--- a/css-writing-modes-3/reference/writing-mode-horizontal-001r-ref.html
+++ b/css-writing-modes-3/reference/writing-mode-horizontal-001r-ref.html
@@ -7,6 +7,7 @@
 <style>
 .test {
   font-size: 5em;
+  line-height: 1;
   direction: rtl;
 }
 </style>

--- a/css-writing-modes-3/text-combine-upright-value-all-002.html
+++ b/css-writing-modes-3/text-combine-upright-value-all-002.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">ABC</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-all-003.html
+++ b/css-writing-modes-3/text-combine-upright-value-all-003.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">ABCDE</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits2-002.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits2-002.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">12</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits2-003.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits2-003.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright-value-digits3-001.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits3-001.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">12</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits3-002.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits3-002.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">123</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits3-003.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits3-003.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright-value-digits4-001.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits4-001.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">123</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits4-002.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits4-002.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 
@@ -23,7 +24,7 @@
 </head>
 <body>
 
-<p>Test passes if there are 2 <strong>identical</strong> black rectangles.</p>
+<p>Test passes if there are 2 <strong>identical</strong> black squares.</p>
 
 <div class="test">
   <p><span class="tcy">1234</span></p>

--- a/css-writing-modes-3/text-combine-upright-value-digits4-003.html
+++ b/css-writing-modes-3/text-combine-upright-value-digits4-003.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/text-combine-upright-value-none-001.html
+++ b/css-writing-modes-3/text-combine-upright-value-none-001.html
@@ -13,6 +13,7 @@
 .test {
   writing-mode: vertical-rl;
   font-size: 5em;
+  line-height: 1;
   font-family: Ahem;
 }
 

--- a/css-writing-modes-3/writing-mode-horizontal-001l.html
+++ b/css-writing-modes-3/writing-mode-horizontal-001l.html
@@ -11,6 +11,7 @@
 .test {
   writing-mode: horizontal-tb;
   font-size: 5em;
+  line-height: 1;
 }
 
 .tcy {

--- a/css-writing-modes-3/writing-mode-horizontal-001r.html
+++ b/css-writing-modes-3/writing-mode-horizontal-001r.html
@@ -11,6 +11,7 @@
 .test {
   writing-mode: horizontal-tb;
   font-size: 5em;
+  line-height: 1;
   direction: rtl;
 }
 


### PR DESCRIPTION
Gérard told me that browsers differ on default line-height values.
https://lists.w3.org/Archives/Public/public-css-testsuite/2015Jun/0039.html

The commit includes fix for wording ("rectangles" to "squares") for a few tests.