### PR TITLE
Add test of `cursor` on element underneath a <select> menu

### DIFF
--- a/css-ui-3/select-cursor-001-manual.html
+++ b/css-ui-3/select-cursor-001-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test (User Interface): cursor property and select element</title>
+  <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+  <link rel="help" href="https://drafts.csswg.org/css-ui-3/#cursor">
+  <link rel="help" href="https://drafts.csswg.org/css2/ui.html#cursor-props">
+  <meta name="flags" content="HTMLonly interact">
+  <meta name="assert" content="Hovering the pointer over a select menu on top of an element with a cursor set should not display said cursor">
+  <style>
+div {
+  cursor: help;
+  height: 200px;
+  width: 200px;
+  background-color: blue;
+}
+  </style>
+</head>
+<body>
+  <ol>
+    <li>If clicking a &lt;select&gt; opens a native widget which is modal, then SKIP this test.</li>
+    <li>Click on the &lt;select&gt; below. A selection widget appears.</li>
+    <li>Move the pointer so that it is hovering within the intersection area of the selection widget and the blue box below.</li>
+    <li>If the "help" cursor is displayed, then the test result is FAILED. Otherwise, it is PASSED.</li>
+  </ol>
+  <select>
+    <option>AAAAAAAA</option>
+    <option>BBBBBBBB</option>
+    <option>CCCCCCCC</option>
+    <option>DDDDDDDD</option>
+    <option>EEEEEEEE</option>
+    <option>FFFFFFFF</option>
+    <option>GGGGGGGG</option>
+    <option>HHHHHHHH</option>
+  </select>
+  <div></div>
+</body>
+</html>


### PR DESCRIPTION
Refs:
* https://connect.microsoft.com/IE/feedback/details/963961/when-hovering-over-a-select-menu-item-the-cursor-for-the-element-underneath-the-menu-is-displayed
* https://github.com/twbs/bootstrap/issues/14528