### PR TITLE
Replace getPropertyCSSValue to getPropertyValue for css transforms

### DIFF
--- a/css-transforms-1/transform_translate_invalid_prefixed.html
+++ b/css-transforms-1/transform_translate_invalid_prefixed.html
@@ -6,39 +6,22 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(null, null) that an expection is to be thrown"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform sets translate(null, null) is invalid,
+                                 transform style get default value.">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(null, null)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(null, null)";
-        document.getElementById("test").style.msTransform = "translate(null, null)";
-        document.getElementById("test").style.oTransform = "translate(null, null)";
-        document.getElementById("test").style.transform = "translate(null, null)"; */
- 
-        // Verify that the transform was set as expected
-        var result;
-        var value;
-        try {
-            value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-            /* value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-            result = false;
-        } catch (e) {
-            result = true;
-            value = e.message;
-        }
-        
-        test(function() {assert_true(result,
-                        "transform should be translate(null, null)")}, 
-                        "transform_translate_null_null");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(null, null)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "none", "transform should be none");
+        }, "transform_translate_null_null");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_max_prefixed.html
+++ b/css-transforms-1/transform_translate_max_prefixed.html
@@ -6,39 +6,22 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE) that an expection is to be thrown"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE) is invalid,
+                                 transform style get default value.">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(INFINITE, INFINITE)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(INFINITE, INFINITE)";
-        document.getElementById("test").style.msTransform = "translate(INFINITE, INFINITE)";
-        document.getElementById("test").style.oTransform = "translate(INFINITE, INFINITE)";
-        document.getElementById("test").style.transform = "translate(INFINITE, INFINITE)"; */
- 
-        // Verify that the transform was set as expected
-        var result;
-        var value;
-        try {
-            value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-            /* value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-            result = false;
-        } catch (e) {
-            result = true;
-            value = e.message;
-        }
-        
-        test(function() {assert_true(result,
-                        "transform should be translate(INFINITE, INFINITE)")}, 
-                        "transform_translate_max");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            document.getElementById("test").style.transform = "translate(INFINITE, INFINITE)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "none", "transform should be none");
+        }, "transform_translate_max");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_min_prefixed.html
+++ b/css-transforms-1/transform_translate_min_prefixed.html
@@ -6,39 +6,22 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE) that an expection is to be thrown"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE) is invalid,
+                                 transform style get default value.">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(-INFINITE, -INFINITE)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(-INFINITE, -INFINITE)";
-        document.getElementById("test").style.msTransform = "translate(-INFINITE, -INFINITE)";
-        document.getElementById("test").style.oTransform = "translate(-INFINITE, -INFINITE)";
-        document.getElementById("test").style.transform = "translate(-INFINITE, -INFINITE)"; */
- 
-        // Verify that the transform was set as expected
-        var result;
-        var value;
-        try {
-            value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-            /* value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-            value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-            result = false;
-        } catch (e) {
-            result = true;
-            value = e.message;
-        }
-        
-        test(function() {assert_true(result,
-                        "transform should be translate(-INFINITE, -INFINITE)")}, 
-                        "transform_translate_min_prefixed");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(-INFINITE, -INFINITE)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "none", "transform should be none");
+        }, "transform_translate_min_prefixed");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_neg_prefixed.html
+++ b/css-transforms-1/transform_translate_neg_prefixed.html
@@ -6,32 +6,21 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(-1px, -1px)"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform supports translate(-1px, -1px)">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(-1px, -1px)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(-1px, -1px)";
-        document.getElementById("test").style.msTransform = "translate(-1px, -1px)";
-        document.getElementById("test").style.oTransform = "translate(-1px, -1px)";
-        document.getElementById("test").style.transform = "translate(-1px, -1px)"; */
- 
-        // Verify that the transform was set as expected
-        var value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-        /* var value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-        
-        test(function() {assert_equals(value,
-                        "translate(-1px, -1px)",
-                        "transform should be translate(-1px, - 1px)")}, 
-                        "transform_translate_-1px_-1px");
-    </script>    
+    <script> 
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(-1px, -1px)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "matrix(1, 0, 0, 1, -1, -1)", "transform should be matrix(1, 0, 0, 1, -1, -1)");
+        }, "transform_translate_-1px_-1px");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_prefixed.html
+++ b/css-transforms-1/transform_translate_prefixed.html
@@ -6,32 +6,21 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(100px, 100px)"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform supports translate(100px, 100px)">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(100px, 100px)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(100px, 100px)";
-        document.getElementById("test").style.msTransform = "translate(100px, 100px)";
-        document.getElementById("test").style.oTransform = "translate(100px, 100px)";
-        document.getElementById("test").style.transform = "translate(100px, 100px)"; */
- 
-        // Verify that the transform was set as expected
-        var value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-        /* var value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-        
-        test(function() {assert_equals(value,
-                        "translate(100px, 100px)",
-                        "transform should be translate(100px, 100px)")}, 
-                        "transform_translate_100px_100px");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(100px, 100px)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "matrix(1, 0, 0, 1, 100, 100)", "transform should be matrix(1, 0, 0, 1, 100, 100)");
+        }, "transform_translate_100px_100px");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_second_omited_prefixed.html
+++ b/css-transforms-1/transform_translate_second_omited_prefixed.html
@@ -6,32 +6,21 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(100px)"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform supports translate(100px)">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(100px)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(100px)";
-        document.getElementById("test").style.msTransform = "translate(100px)";
-        document.getElementById("test").style.oTransform = "translate(100px)";
-        document.getElementById("test").style.transform = "translate(100px)"; */
- 
-        // Verify that the transform was set as expected
-        var value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-        /* var value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-        
-        test(function() {assert_equals(value,
-                        "translate(100px)",
-                        "transform should be translate(100px)")}, 
-                        "transform_translate_100px");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(100px)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "matrix(1, 0, 0, 1, 100, 0)", "transform should be matrix(1, 0, 0, 1, 100, 0)");
+        }, "transform_translate_100px");
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_zero_prefixed.html
+++ b/css-transforms-1/transform_translate_zero_prefixed.html
@@ -6,32 +6,21 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(0, 0)"> 
-    <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <meta name="assert" content="Check if transform supports translate(0, 0)">
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
     <div id="log"></div>
-    <script type="text/javascript">
-        // Set the transform 
-        document.getElementById("test").style.webkitTransform = "translate(0, 0)";
-        /* document.getElementById("test").style.mozkitTransform = "translate(0, 0)";
-        document.getElementById("test").style.msTransform = "translate(0, 0)";
-        document.getElementById("test").style.oTransform = "translate(0, 0)";
-        document.getElementById("test").style.transform = "translate(0, 0)"; */
- 
-        // Verify that the transform was set as expected
-        var value = document.getElementById("test").style.getPropertyCSSValue("-webkit-transform").cssText;
-        /* var value = document.getElementById("test").style.getPropertyCSSValue("-moz-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-ms-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("-0-transform").cssText;
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText; */
-        
-        test(function() {assert_equals(value,
-                        "translate(0px, 0px)",
-                        "transform should be translate(0px, 0px)")}, 
-                        "transform_translate_0_0");
-    </script>    
+    <script>
+        var div = document.getElementById("test");
+        test(function() {
+            div.style.transform = "translate(0, 0)";
+            var value = window.getComputedStyle(div).getPropertyValue("transform");
+
+            assert_equals(value, "matrix(1, 0, 0, 1, 0, 0)", "transform should be matrix(1, 0, 0, 1, 0, 0)");
+        }, "transform_translate_0_0");
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- It doesn't distinguish 'getPropertyCSSValue' is a function in chrome, and it returns null when use domelement.style.getPropertyCSSValue() in firefox.
- Use unprefix property