### PR TITLE
[CSS22][css-tables][mediaqueries][css3-mediaqueries] Add test of table layout after resizing viewport

### DIFF
--- a/mediaqueries-3/min-width-tables-001.html
+++ b/mediaqueries-3/min-width-tables-001.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <meta charset="utf-8">
+    <title>CSS Test: Table Layout and Viewport Resizing</title>
+    <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+    <link rel="help" href="https://drafts.csswg.org/css2/tables.html#auto-table-layout">
+    <link rel="help" href="https://drafts.csswg.org/mediaqueries-3/#width">
+    <link rel="help" href="https://drafts.csswg.org/mediaqueries-4/#width">
+    <link rel="match" href="min-width-tables-001-ref.html">
+    <meta name="flags" content="dom">
+    <meta name="assert" content="Resizing a page which toggles the `display` of elements between `block` and `table-cell` based on the viewport width should not cause unnecessary wrapping of the table.">
+    <style>
+iframe {
+    border: 0;
+}
+    </style>
+</head>
+<body>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <iframe id="toy" width="100" height="300" src="support/min-width-tables-001-iframe.html"></iframe>
+    <!-- See min-width-tables-001-iframe.html for the derivation of the 100px value -->
+    <!-- We use 300px height so the incorrect stacking is visible in failure cases -->
+    <!-- This test is not about iframes specifically. It's just that resizing an iframe is more reliable than resizing the window, given browser security restrictions. -->
+    <script>
+    window.addEventListener('load', function () {
+        var PAINT_MS = 250;/* Assume the browser takes about this long to layout/paint this whole page */
+        var iframe = document.getElementById('toy');
+        window.setTimeout(function () {
+            iframe.width = 64;/* <100px ; toggle media query off */
+            window.setTimeout(function () {
+                iframe.width = 100;/* >=100px ; toggle media query on; back to initial width */
+                // Take the reftest screenshot after the last relayout/repaint finishes
+                window.setTimeout(function () {
+                    document.documentElement.className = '';
+                }, PAINT_MS);
+            }, PAINT_MS);
+        }, PAINT_MS);
+    }, false);
+    </script>
+</body>
+</html>

--- a/mediaqueries-3/min-width-tables-001.html
+++ b/mediaqueries-3/min-width-tables-001.html
@@ -13,6 +13,7 @@
     <style>
 iframe {
     border: 0;
+    overflow: hidden;
 }
     </style>
 </head>

--- a/mediaqueries-3/min-width-tables-001.html
+++ b/mediaqueries-3/min-width-tables-001.html
@@ -13,7 +13,6 @@
     <style>
 iframe {
     border: 0;
-    overflow: hidden;
 }
     </style>
 </head>

--- a/mediaqueries-3/support/min-width-tables-001-iframe.html
+++ b/mediaqueries-3/support/min-width-tables-001-iframe.html
@@ -6,6 +6,7 @@
     <style>
 body {
     margin: 0;
+    overflow: hidden;
 }
 /* green div that should cover the red divs */
 #green {

--- a/mediaqueries-3/support/min-width-tables-001-iframe.html
+++ b/mediaqueries-3/support/min-width-tables-001-iframe.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>iframe containing the meat of the test</title>
+    <style>
+body {
+    margin: 0;
+}
+/* green div that should cover the red divs */
+#green {
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: green;
+    width: 100%;
+    height: 600px;
+}
+.spacer {
+    height: 98px;
+    width: 20px;
+}
+.item {
+    background-color: red;
+    display: block;/* property under test */
+    /* border to aid understanding of boundaries between items */
+    border-style: solid;
+    border-width: 1px;
+    border-color: red;/* Note: if you're trying to debug this, use a different color here */
+}
+/* 100px = 10*(1 + 8 + 1) */
+@media (min-width: 100px) {
+    #green {
+        width: 100px;
+        height: 100px;/* = 1 + 98 + 1 */
+    }
+    .item {
+        display: table-cell;/* property and value under test */
+    }
+}
+    </style>
+</head>
+<body>
+    <div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+        <div class="item"><div class="spacer"></div></div>
+    </div>
+    <div id="green"></div>
+</body>
+</html>


### PR DESCRIPTION
Refs http://wkbug.com/138167, https://github.com/twbs/bootstrap/issues/9774
I tried to avoid using `<iframe>` in the reference file, but browsers seem to apply an inconsistent magic bottom margin to the testcase `<iframe>`, so I couldn't get the `<p>`'s vertical position to match consistently.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/812)
<!-- Reviewable:end -->
