### PR TITLE
Update border color tests for 4 digit hex color values.

### DIFF
--- a/css21/borders/border-bottom-color-030.xht
+++ b/css21/borders/border-bottom-color-030.xht
@@ -6,10 +6,9 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-05-20 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
-        <link rel="match" href="../reference/ref-filled-black-96px-square.xht" />
-
+        <link rel="match" href="../reference/ref-transparent-square.xht" />
         <meta name="flags" content="invalid" />
-        <meta name="assert" content="The 'border-bottom-color' set to #1000 falls back to the initial value." />
+        <meta name="assert" content="The 'border-bottom-color' set to #1000 is a transparent dark red square." />
         <style type="text/css">
             div
             {
@@ -22,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black square.</p>
+        <p>Test passes if there is a transparent square.</p>
         <div></div>
     </body>
 </html>

--- a/css21/borders/border-left-color-030.xht
+++ b/css21/borders/border-left-color-030.xht
@@ -6,10 +6,10 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-05-26 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-left-color" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
-        <link rel="match" href="../reference/ref-filled-black-96px-square.xht" />
+        <link rel="match" href="../reference/ref-transparent-square.xht" />
 
         <meta name="flags" content="invalid" />
-        <meta name="assert" content="The 'border-left-color' set to #1000 falls back to the initial value." />
+        <meta name="assert" content="The 'border-top-color' set to #1000 is a transparent dark red square." />
         <style type="text/css">
             div
             {
@@ -21,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black square.</p>
+        <p>Test passes if there is a transparent square.</p>
         <div></div>
     </body>
 </html>

--- a/css21/borders/border-right-color-030.xht
+++ b/css21/borders/border-right-color-030.xht
@@ -6,10 +6,10 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-02 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-right-color" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
-		<link rel="match" href="border-right-color-007-ref.xht" />
+	<link rel="match" href="../reference/ref-transparent-square.xht" />
 
         <meta name="flags" content="invalid" />
-        <meta name="assert" content="The 'border-right-color' set to #1000 falls back to the initial value." />
+        <meta name="assert" content="The 'border-right-color' set to #1000 is a transparent dark red square." />
         <style type="text/css">
             div
             {
@@ -21,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a box below.</p>
+        <p>Test passes if there is a transparent square.</p>
         <div></div>
     </body>
 </html>

--- a/css21/borders/border-top-color-030.xht
+++ b/css21/borders/border-top-color-030.xht
@@ -6,10 +6,10 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-05-26 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
-        <link rel="match" href="../reference/ref-filled-black-96px-square.xht" />
+        <link rel="match" href="../reference/ref-transparent-square.xht" />
 
         <meta name="flags" content="invalid" />
-        <meta name="assert" content="The 'border-top-color' set to #1000 falls back to the initial value." />
+        <meta name="assert" content="The 'border-top-color' set to #1000 is a transparent dark red square." />
         <style type="text/css">
             div
             {
@@ -22,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black square.</p>
+        <p>Test passes if there is a transparent square.</p>
         <div></div>
     </body>
 </html>

--- a/css21/reference/ref-transparent-square.xht
+++ b/css21/reference/ref-transparent-square.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Jack Moffitt" href="http://metajack.im/" />
+
+  <style type="text/css"><![CDATA[
+  div
+  {
+  height: 96px;
+  width: 96px;
+  }
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there is a transparent square.</p>
+
+  <div></div>
+
+ </body>
+</html>


### PR DESCRIPTION
Servo now supports 4 digit hex color values, and this caused some css21 tests to start failing. This updates the tests.