### PR TITLE
Support for getPropertyValue to return empty string

### DIFF
--- a/css-shapes-1/shape-outside/values/support/parsing-utils.js
+++ b/css-shapes-1/shape-outside/values/support/parsing-utils.js
@@ -116,7 +116,7 @@ function buildTestCases(testCases, testType) {
 
         // expected
         if( type.indexOf('invalid') != -1 ){
-            oneTestCase.push(null)
+            oneTestCase.push("")
         } else if( type == 'inline' ) {
             oneTestCase.push(test['expected_inline']);
         } else if( type == 'computed' ){
@@ -174,7 +174,7 @@ function buildPositionTests(shape, valid, type, units) {
                 testCase = new Array();
                 testCase.push(testValue + ' is invalid');
                 testCase.push(testValue);
-                testCase.push(null);
+                testCase.push("");
                 results.push(testCase);
             });
         }


### PR DESCRIPTION
 getPropertyValue returns en empty string in both IE. In chrome there is a proposed changed to update getPropertyValue with an empty string instead of returning null.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/815)

<!-- Reviewable:end -->
