### PR TITLE
Update transforms getPropertyCSSValue tests

### DIFF
--- a/css-transforms-1/transform_translate.html
+++ b/css-transforms-1/transform_translate.html
@@ -17,7 +17,7 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(100px, 100px)";
         var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
-        assert_equals(value, "translate(100px, 100px)")
+        assert_equals(value, "matrix(1, 0, 0, 1, 100, 100)")
     }, "transform_translate_100px_100px");
     </script>
 </body>

--- a/css-transforms-1/transform_translate.html
+++ b/css-transforms-1/transform_translate.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(100px, 100px)"> 
+    <meta name="assert" content="Check if transform supports translate(100px, 100px)">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -16,9 +16,9 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(100px, 100px)";
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText;
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
         assert_equals(value, "translate(100px, 100px)")
     }, "transform_translate_100px_100px");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_invalid.html
+++ b/css-transforms-1/transform_translate_invalid.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(null, null) that an expection is to be thrown"> 
+    <meta name="assert" content="Check if transform sets translate(null, null) that an expection is to be thrown">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -18,9 +18,9 @@
         document.getElementById("test").style.transform = "translate(null, null)";
  
         assert_throws(null, function() {
-            document.getElementById("test").style.getPropertyCSSValue("transform").cssText;
+            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
         });
     }, "transform_translate_null_null");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_invalid.html
+++ b/css-transforms-1/transform_translate_invalid.html
@@ -6,7 +6,8 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(null, null) that an expection is to be thrown">
+    <meta name="assert" content="Check if transform sets translate(null, null),
+                                 transform property returns initial value.">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
     <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
@@ -16,10 +17,8 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(null, null)";
- 
-        assert_throws(null, function() {
-            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
-        });
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
+        assert_equals(value, "none", "transform property value should be none");
     }, "transform_translate_null_null");
     </script>
 </body>

--- a/css-transforms-1/transform_translate_max.html
+++ b/css-transforms-1/transform_translate_max.html
@@ -6,7 +6,8 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE) that an expection is to be thrown">
+    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE),
+                                 transform property returns initial value.">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
     <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
@@ -16,9 +17,8 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(INFINITE, INFINITE)";
-        assert_throws(null, function() {
-            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform")
-        })
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
+        assert_equals(value, "none", "transform property value should be none");
     }, "transform_translate_max");
     </script>
 </body>

--- a/css-transforms-1/transform_translate_max.html
+++ b/css-transforms-1/transform_translate_max.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE) that an expection is to be thrown"> 
+    <meta name="assert" content="Check if transform sets translate(INFINITE, INFINITE) that an expection is to be thrown">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -17,9 +17,9 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(INFINITE, INFINITE)";
         assert_throws(null, function() {
-            document.getElementById("test").style.getPropertyCSSValue("transform").cssText
+            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform")
         })
     }, "transform_translate_max");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_min.html
+++ b/css-transforms-1/transform_translate_min.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE) that an expection is to be thrown"> 
+    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE) that an expection is to be thrown">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -17,9 +17,9 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(-INFINITE, -INFINITE)";
         assert_throws(null, function() {
-            document.getElementById("test").style.getPropertyCSSValue("transform").cssText
+            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform")
         })
     }, "transform_translate_min");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_min.html
+++ b/css-transforms-1/transform_translate_min.html
@@ -6,7 +6,8 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE) that an expection is to be thrown">
+    <meta name="assert" content="Check if transform sets translate(-INFINITE, -INFINITE),
+                                 transform property returns initial value.">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
     <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
@@ -16,9 +17,8 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(-INFINITE, -INFINITE)";
-        assert_throws(null, function() {
-            window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform")
-        })
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
+        assert_equals(value, "none", "transform property value should be none");
     }, "transform_translate_min");
     </script>
 </body>

--- a/css-transforms-1/transform_translate_neg.html
+++ b/css-transforms-1/transform_translate_neg.html
@@ -17,7 +17,7 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(-1px, -1px)";
         var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
-        assert_equals(value, "translate(-1px, -1px)")
+        assert_equals(value, "matrix(1, 0, 0, 1, -1, -1)")
     }, "transform_translate_-1px_-1px");
     </script>
 </body>

--- a/css-transforms-1/transform_translate_neg.html
+++ b/css-transforms-1/transform_translate_neg.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(-1px, -1px)"> 
+    <meta name="assert" content="Check if transform supports translate(-1px, -1px)">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -16,9 +16,9 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(-1px, -1px)";
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText;
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
         assert_equals(value, "translate(-1px, -1px)")
     }, "transform_translate_-1px_-1px");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_second_omited.html
+++ b/css-transforms-1/transform_translate_second_omited.html
@@ -17,7 +17,7 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(100px)";
         var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
-        assert_equals(value, "translate(100px)")
+        assert_equals(value, "matrix(1, 0, 0, 1, 100, 0)")
     }, "transform_translate_100px");
     </script>
 </body>

--- a/css-transforms-1/transform_translate_second_omited.html
+++ b/css-transforms-1/transform_translate_second_omited.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(100px)"> 
+    <meta name="assert" content="Check if transform supports translate(100px)">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -16,9 +16,9 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(100px)";
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText;
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
         assert_equals(value, "translate(100px)")
     }, "transform_translate_100px");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_zero.html
+++ b/css-transforms-1/transform_translate_zero.html
@@ -6,9 +6,9 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <meta name="flags" content="dom">
-    <meta name="assert" content="Check if transform supports translate(0, 0)"> 
+    <meta name="assert" content="Check if transform supports translate(0, 0)">
     <script type="text/javascript" src="../../resources/testharness.js"></script>
-    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>    
+    <script type="text/javascript" src="../../resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="test"></div>
@@ -16,9 +16,9 @@
     <script type="text/javascript">
     test(function() {
         document.getElementById("test").style.transform = "translate(0, 0)";
-        var value = document.getElementById("test").style.getPropertyCSSValue("transform").cssText;
+        var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
         assert_equals(value, "translate(0px, 0px)")
     }, "transform_translate_0_0");
-    </script>    
+    </script>
 </body>
 </html>

--- a/css-transforms-1/transform_translate_zero.html
+++ b/css-transforms-1/transform_translate_zero.html
@@ -17,7 +17,7 @@
     test(function() {
         document.getElementById("test").style.transform = "translate(0, 0)";
         var value = window.getComputedStyle(document.getElementById("test")).getPropertyValue("transform");
-        assert_equals(value, "translate(0px, 0px)")
+        assert_equals(value, "matrix(1, 0, 0, 1, 0, 0)")
     }, "transform_translate_0_0");
     </script>
 </body>


### PR DESCRIPTION
- The latest W3C spec: http://www.w3.org/TR/cssom/#cssstyledeclaration has removed function getPropertyCSSValue, so use function getPropertyValue to get property value instead.

- CSS Transforms spec: http://www.w3.org/TR/css-transforms-1/#transform-property says the final transformation value for a coordinate system will be converted to in the list to its corresponding matrix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/822)
<!-- Reviewable:end -->
