### PR TITLE
css-variables-1: Update from var- syntax

### DIFF
--- a/css-variables-1/css-vars-custom-property-case-sensitive-001.html
+++ b/css-variables-1/css-vars-custom-property-case-sensitive-001.html
@@ -1,27 +1,28 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>CSS Variables Test: custom property names start with "var-" in lower case</title>
+    <title>CSS Variables Test: custom property names are case-sensitive</title>
     <meta charset="UTF-8">
     <link rel="author" title="Noah Collins" href="mailto:noahcollins@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
-    <meta name="assert" content="Custom property names start with var- which must be lower case">
+    <meta name="assert" content="Custom property names are case-sensitive">
     <link rel="match" href="reference/css-vars-custom-property-case-sensitive-ref.html">
     <style type="text/css">
         :root {
-            /* these should be VALID custom property names */
-            var-veryblue:   #22e;
-            var-AlsoBlue:   #22e;
+            --veryblue:   #22e;
+            --AlsoBlue:   #22e;
 
-            /* these should be INVALID custom property names */
-            VAR-veryred:   #f00;
-            Var-AlsoRed:   #f00;
+            --veryred:   #f00;
+            --AlsoRed:   #f00;
         }
 
-        .blue-good-1  { color: var(veryblue); }
-        .blue-good-2  { color: var(AlsoBlue); }
-        .red-bad-1    { color: var(veryred);  }
-        .red-bad-2    { color: var(AlsoRed);  }
+        /* These match the case of the declarations */
+        .blue-good-1  { color: var(--veryblue); }
+        .blue-good-2  { color: var(--AlsoBlue); }
+
+        /* These DO NOT match the case of the declarations */
+        .red-bad-1    { color: var(--VeryRed);  }
+        .red-bad-2    { color: var(--alsored);  }
     </style>
 </head>
 <body>

--- a/css-variables-1/css-vars-custom-property-inheritance.html
+++ b/css-variables-1/css-vars-custom-property-inheritance.html
@@ -10,14 +10,14 @@
     <style type="text/css">
 
         /* test cascade importance */
-        :root { var-color: #1c1 !important; }
-        :root { var-color: red; }
+        :root { --color: #1c1 !important; }
+        :root { --color: red; }
 
         /* test cascade order */
         * { color: red; }
 
         /* test cascade order */
-        * { color: var(color); }
+        * { color: var(--color); }
 
     </style>
 </head>

--- a/css-variables-1/reference/css-vars-custom-property-case-sensitive-ref.html
+++ b/css-variables-1/reference/css-vars-custom-property-case-sensitive-ref.html
@@ -1,24 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>CSS Variables Test: custom property names start with "var-" in lower case</title>
+    <title>CSS Variables Test: custom property names are case-sensitive</title>
     <meta charset="UTF-8">
     <link rel="author" title="Noah Collins" href="mailto:noahcollins@gmail.com">
     <style type="text/css">
-        :root {
-            /* these should be VALID custom property names */
-            var-veryblue:   #22e;
-            var-AlsoBlue:   #22e;
-
-            /* these should be INVALID custom property names */
-            VAR-veryred:   #f00;
-            Var-AlsoRed:   #f00;
-        }
-
-        .blue-good-1  { color: var(veryblue); }
-        .blue-good-2  { color: var(AlsoBlue); }
-        .red-bad-1    { color: var(veryred);  }
-        .red-bad-2    { color: var(AlsoRed);  }
+        .blue-good-1  { color: #22e; }
+        .blue-good-2  { color: #22e; }
     </style>
 </head>
 <body>

--- a/css-variables-1/test_variable_legal_values.html
+++ b/css-variables-1/test_variable_legal_values.html
@@ -63,13 +63,13 @@ function run() {
   function assert_allowed_variable_value(value, description) {
     test(function() {
            styleText.data = "#test { \n" +
-                            "  var-test: red;\n" +
-                            "  var-test: " + value + ";\n" +
+                            "  --test: red;\n" +
+                            "  --test: " + value + ";\n" +
                             "  background-color: red;\n" +
-                            "  background-color: var(test);\n" +
+                            "  background-color: var(--test);\n" +
                             "}";
-           assert_true(initial_cs != red_cs &&
-                       initial_cs == test_cs.backgroundColor);
+           assert_not_equals(initial_cs, red_cs);
+           assert_equals(initial_cs, test_cs.backgroundColor);
          },
          description_to_name(description),
          { assert: "Value allowed within variable: " + description });
@@ -78,13 +78,13 @@ function run() {
   function assert_disallowed_balanced_variable_value(value, description) {
     test(function() {
            styleText.data = "#test { \n" +
-                            "  var-test: green;\n" +
-                            "  var-test: " + value + ";\n" +
+                            "  --test: green;\n" +
+                            "  --test: " + value + ";\n" +
                             "  background-color: red;\n" +
-                            "  background-color: var(test);\n" +
+                            "  background-color: var(--test);\n" +
                             "}";
-           assert_true(green_cs != red_cs &&
-                       green_cs == test_cs.backgroundColor);
+           assert_not_equals(green_cs, red_cs);
+           assert_equals(green_cs, test_cs.backgroundColor);
          },
          description_to_name(description),
          { assert: "Value not allowed within variable: " + description });


### PR DESCRIPTION
Replace `var-foo` and `var(foo)` in tests with `--foo` and `var(--foo)` per spec change.

Rewrite `css-vars-custom-property-case-sensitive-001` to test the case-sensitivity of the property name rather than just of the `var-` prefix, since the new `--` prefix has no case.

r? @Ms2ger

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/847)
<!-- Reviewable:end -->
