### PR TITLE
Remove the unnecessary dependency on a Mercurial repository in build.py.

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -12,7 +12,7 @@ import optparse
 import shutil
 from apiclient import apiclient
 from w3ctestlib import Sources, Utils, Suite, Indexer
-from mercurial import hg, ui
+from mercurial import ui
 
 
 
@@ -22,7 +22,7 @@ class Builder(object):
         self.ui = ui
         self.skipDirs = ('support')
         self.rawDirs = {'other-formats': 'other'}
-        self.sourceTree = Sources.SourceTree(hg.repository(ui, '.'))
+        self.sourceTree = Sources.SourceTree()
         self.sourceCache = Sources.SourceCache(self.sourceTree)
         self.cacheDir = 'tools/cache'
         self.outputPath = outputPath.rstrip('/') if (outputPath) else 'dist'


### PR DESCRIPTION
The argument to SourceTree is never used. This allows a build to finish in a
git clone of the repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/851)
<!-- Reviewable:end -->
