### PR TITLE
css21/visuren/left-offset-position-fixed-001.xht: Add missing review datestamp

### DIFF
--- a/css21/visuren/left-offset-position-fixed-001.xht
+++ b/css21/visuren/left-offset-position-fixed-001.xht
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Test: left:auto offset of position:fixed box in a position:relative containing block</title>
     <link rel="author" title="Chris Rebert" href="http://chrisrebert.com" />
-    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />  <!-- 2015-09-17 -->
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#position-props" title="9.3.2 Box offsets: 'top', 'right', 'bottom', 'left'" />
     <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width" title="10.3.7 Absolutely positioned, non-replaced elements" />
     <link rel="help" href="https://drafts.csswg.org/css2/visuren.html#position-props" />


### PR DESCRIPTION
Erratum from #813. The datestamp didn't make it into the 2nd file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/864)
<!-- Reviewable:end -->
