### PR TITLE
[css-flexbox] Fix the css-box-justify-content testcase

### DIFF
--- a/css-flexbox-1/css-box-justify-content.html
+++ b/css-flexbox-1/css-box-justify-content.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>flexbox |css-box-justufy-content</title>
+<title>flexbox |css-box-justify-content</title>
 <link rel="author" href="ava656094@gmail.com" title="xiaoxia">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
@@ -14,7 +14,6 @@
 	justify-content: flex-end;
 }
 .item{
-	margin-left:2px;
 	width:50px;
 	height: 30px;
 	}
@@ -23,8 +22,12 @@
 <p>This test passes if the DIV5's position in the end and the div is Horizontal layout</p>
 <div id="flexbox">
 	<div class="item" style="background-color: rgb(242, 210, 80); color: rgb(41, 119, 248);">DIV1</div>
+    &nbsp;
 	<div class="item" style="background-color: rgb(110, 8, 7); color: rgb(162, 152, 22);">DIV2</div>
+    &nbsp;
 	<div class="item" style="background-color: rgb(215, 172, 243); color: rgb(74, 123, 110);">DIV3</div>
+    &nbsp;
 	<div class="item" style="background-color: rgb(242, 133, 80); color: rgb(41, 119, 248);">DIV4</div>
+    &nbsp;
 	<div class="item" style="background-color: rgb(242, 50, 80); color: rgb(41, 119, 248);">DIV5</div>
 </div>

--- a/css-flexbox-1/reference/css-box-justify-content-ref.html
+++ b/css-flexbox-1/reference/css-box-justify-content-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>flexbox |css-box-justufy-content</title>
+<title>flexbox |css-box-justify-content</title>
 <link rel="author" href="ava656094@gmail.com" title="xiaoxia">
 <style>
 #flexbox {
@@ -11,7 +11,7 @@
 }
 .item{
 	display: inline-block;
-	align:right;
+	text-align:left;
 	width:50px;
 	height: 30px;
 	}


### PR DESCRIPTION
- text-align must be left inside the inner boxes, because
  we only want to use text-align to align the boxes themselves,
  we don't want to change the contents
- Use nbsp instead of margin-left for spacing to ensure the same
  width as the spaces in the reference rendering