### PR TITLE
[css-flexbox] fix css-flexbox-img-expand-evenly.html

### DIFF
--- a/css-flexbox-1/css-flexbox-img-expand-evenly.html
+++ b/css-flexbox-1/css-flexbox-img-expand-evenly.html
@@ -9,7 +9,7 @@
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="reference/css-flexbox-img-expand-evenly-ref.html">
     <meta name="flags" content="">
-    <meta name="assert" content="3 square images fill out border.">
+    <meta name="assert" content="3 rectangular images fill out border.">
     <style type="text/css">
    
        /* ADD STYLE BLOCK HERE (PREFERRABLE TO INLINE STYLES) */
@@ -29,7 +29,7 @@
     </style>
 </head>
 <body>
-    <p>3 square images fill out border.</p>
+    <p>3 rectangular images fill out border.</p>
     
     <!-- PAGE CONTENT -->
     <div class="flexbox">

--- a/css-flexbox-1/reference/css-flexbox-img-expand-evenly-ref.html
+++ b/css-flexbox-1/reference/css-flexbox-img-expand-evenly-ref.html
@@ -21,13 +21,14 @@
     </style>
 </head>
 <body>
-    <p>3 square images fill out border.</p>
+    <p>3 rectangular images fill out border.</p>
     
     <!-- PAGE CONTENT -->
     <div class="flexbox">
-        <img src="support/solidblue.png" />
-        <img src="support/solidblue.png" />
-        <img src="support/solidblue.png" />
+        <!-- It is important that there is no linebreak between the <img> tags.
+             The line break would be rendered as whitespace, breaking the test.
+          -->
+        <img src="../support/solidblue.png" /><img src="../support/solidblue.png" /><img src="../support/solidblue.png" />
     </div>
     
 


### PR DESCRIPTION
- Path to the image file was incorrect
- Linebreak needs to be removed, see comment in patch

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/877)
<!-- Reviewable:end -->
