### PR TITLE
[css-flexbox] fix flex-align-items-center-ref.html

### DIFF
--- a/css-flexbox-1/reference/flex-align-items-center-ref.html
+++ b/css-flexbox-1/reference/flex-align-items-center-ref.html
@@ -18,8 +18,8 @@
 				left: 10px;
 			}
 			#a {
-				top: 150px;
-				left: 230px;
+				top: 148px;
+				left: 239px;
 				border: 2px dotted blue;
 				background: green;
 				border-radius: 3px;
@@ -30,8 +30,8 @@
 				flex: none;
 			}
 			#b {
-				top: 150px;
-				left: 283px;
+				top: 148px;
+				left: 293px;
 				border: 2px dotted blue;
 				background: green;
 				border-radius: 3px;
@@ -42,8 +42,8 @@
 				flex: none;
 			}
 			#c {
-				top: 150px;
-				left: 336px;
+				top: 148px;
+				left: 347px;
 				border: 2px dotted blue;
 				background: green;
 				border-radius: 3px;


### PR DESCRIPTION
The position calculations in the reference were incorrect.  I have manually
verified that my new positioning is correct, and it also matches browser
rendering (tested in Chrome and Firefox nightlies)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/878)
<!-- Reviewable:end -->
