### PR TITLE
[css-flexbox] Fix flex-flexitem-percentage-prescation-ref.html

### DIFF
--- a/css-flexbox-1/reference/flex-flexitem-percentage-prescation-ref.html
+++ b/css-flexbox-1/reference/flex-flexitem-percentage-prescation-ref.html
@@ -23,8 +23,8 @@
 <body>
 <div id="test">
 	<div id="test">
-        <p style="background:green;top:0px;height:300px;left:0px;height:300px;width:50px;">damer</p>
-        <p style="top:0px;left:50px;height:300px;background:Red;width:51px;">damer</p>
+        <p style="background:green;top:0px;height:300px;left:0px;height:300px;width:50.5px;">damer</p>
+        <p style="top:0px;left:50.5px;height:300px;background:Red;width:50.5px;">damer</p>
     </div>
 </div>
 </body>


### PR DESCRIPTION
In truth I don't understand this test, or why its <title> is what it is,
but at least this makes the reference match the testcase. I can only assume
that it was written before fractional pixels were common?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/879)
<!-- Reviewable:end -->
