### PR TITLE
[css-flexbox] fix ttwf-reftest-flex-order-ref.html

### DIFF
--- a/css-flexbox-1/reference/ttwf-reftest-flex-order-ref.html
+++ b/css-flexbox-1/reference/ttwf-reftest-flex-order-ref.html
@@ -24,10 +24,7 @@
 <body>
     <p>The test passed if all the cells are reversed.</p>
     <div class="container">
-      <span class="first">forth</span>
-      <span class="second">third</span>
-      <span class="third">second</span>
-      <span class="forth">first</span>
+      <span class="first">forth</span><span class="second">third</span><span class="third">second</span><span class="forth">first</span>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Remove spaces between <span>s, because they mess up the rendering.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/880)
<!-- Reviewable:end -->
