### PR TITLE
[css-flexbox] Fix flexbox_order-noninteger-invalid.html

### DIFF
--- a/css-flexbox-1/flexbox_order-noninteger-invalid.html
+++ b/css-flexbox-1/flexbox_order-noninteger-invalid.html
@@ -16,7 +16,7 @@ span {
 	flex: 1 0 0%;
 }
 span+span {
-	background: yellow;
+	background: white;
 	order: 0;
 }
 /* irrelevant */


### PR DESCRIPTION
As this test uses an empty reference, it needs to use a white background
for this box.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/882)
<!-- Reviewable:end -->
