### PR TITLE
[css-flexbox] Fix ttwf-reftest-flex-direction-row-reverse.html

### DIFF
--- a/css-flexbox-1/reference/ttwf-reftest-flex-direction-row-reverse-ref.html
+++ b/css-flexbox-1/reference/ttwf-reftest-flex-direction-row-reverse-ref.html
@@ -6,10 +6,10 @@
     <style type="text/css">
         .container {
 	position: relative;
-	display: flex;
 	background: red;
 	margin: 1em 0;
 	border: 1px solid black;
+	text-align: right;
         }
 	span {
 	display: inline-block;
@@ -17,16 +17,14 @@
 	color: white;
 	margin: 1em;
 	width: 8em;
+	text-align: left;
 	}
     </style>
 </head>
 <body>
-    <p>The test passed if you see all the cells are arraged horizontally and the order of cells are reversed.</p>
+    <p>The test passed if you see all the cells are arranged horizontally and the order of cells are reversed.</p>
     <div class="container">
-      <span>forth</span>
-      <span>third</span>
-      <span>second</span>
-      <span>first</span>
+      <span>forth</span><span>third</span><span>second</span><span>first</span>
     </div>
 </body>
 </html>

--- a/css-flexbox-1/ttwf-reftest-flex-direction-row-reverse.html
+++ b/css-flexbox-1/ttwf-reftest-flex-direction-row-reverse.html
@@ -25,7 +25,7 @@
     </style>
 </head>
 <body>
-    <p>The test passed if you see all the cells are arraged horizontally and the order of cells are reversed.</p>
+    <p>The test passed if you see all the cells are arranged horizontally and the order of cells are reversed.</p>
     <div class="container">
       <span>first</span>
       <span>second</span>


### PR DESCRIPTION
The reference should not use flexbox itself. It also was for some reason
not right-aligned. This change fixes that, and also a typo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/885)
<!-- Reviewable:end -->
