### PR TITLE
Fix typos in reference urls in css-text-3/text-align/.

### DIFF
--- a/css-text-3/text-align/text-align-end-001.html
+++ b/css-text-3/text-align/text-align-end-001.html
@@ -5,7 +5,7 @@
 <title>text-align: end, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-001.html'>
+<link rel='match' href='reference/text-align-end-ref-001.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: end; direction: rtl; }

--- a/css-text-3/text-align/text-align-end-002.html
+++ b/css-text-3/text-align/text-align-end-002.html
@@ -5,7 +5,7 @@
 <title>text-align: end, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-002.html'>
+<link rel='match' href='reference/text-align-end-ref-002.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: end; direction: ltr; }

--- a/css-text-3/text-align/text-align-end-003.html
+++ b/css-text-3/text-align/text-align-end-003.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-003.html'>
+<link rel='match' href='reference/text-align-end-ref-003.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-004.html
+++ b/css-text-3/text-align/text-align-end-004.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-004.html'>
+<link rel='match' href='reference/text-align-end-ref-004.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-005.html
+++ b/css-text-3/text-align/text-align-end-005.html
@@ -5,7 +5,7 @@
 <title>text-align: end, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-005.html'>
+<link rel='match' href='reference/text-align-end-ref-005.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: end; direction: rtl; }

--- a/css-text-3/text-align/text-align-end-006.html
+++ b/css-text-3/text-align/text-align-end-006.html
@@ -5,7 +5,7 @@
 <title>text-align: end, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-006.html'>
+<link rel='match' href='reference/text-align-end-ref-006.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: end; direction: ltr; }

--- a/css-text-3/text-align/text-align-end-007.html
+++ b/css-text-3/text-align/text-align-end-007.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-007.html'>
+<link rel='match' href='reference/text-align-end-ref-007.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-008.html
+++ b/css-text-3/text-align/text-align-end-008.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-008.html'>
+<link rel='match' href='reference/text-align-end-ref-008.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-009.html
+++ b/css-text-3/text-align/text-align-end-009.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=auto, RTL first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-009.html'>
+<link rel='match' href='reference/text-align-end-ref-009.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is auto and first strong character is rtl.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-010.html
+++ b/css-text-3/text-align/text-align-end-010.html
@@ -5,7 +5,7 @@
 <title>text-align: end, dir=auto, LTR first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-010.html'>
+<link rel='match' href='reference/text-align-end-ref-010.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is auto and first strong character is ltr.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-014.html
+++ b/css-text-3/text-align/text-align-end-014.html
@@ -5,7 +5,7 @@
 <title>text-align: end, pre, dir=rtl inherited</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-014.html'>
+<link rel='match' href='reference/text-align-end-ref-014.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when base direction is rtl.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-015.html
+++ b/css-text-3/text-align/text-align-end-015.html
@@ -5,7 +5,7 @@
 <title>text-align: end, pre, dir=ltr inherited</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-015.html'>
+<link rel='match' href='reference/text-align-end-ref-015.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when base  direction is  ltr.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-016.html
+++ b/css-text-3/text-align/text-align-end-016.html
@@ -5,7 +5,7 @@
 <title>text-align: end, pre, dir=auto</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-016.html'>
+<link rel='match' href='reference/text-align-end-ref-016.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is auto and first strong character is ltr, and left when first strong is rtl.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-end-017.html
+++ b/css-text-3/text-align/text-align-end-017.html
@@ -5,7 +5,7 @@
 <title>text-align: end, pre, dir=auto on surrounding block</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-end-017.html'>
+<link rel='match' href='reference/text-align-end-ref-017.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. since dir=auto is not inherited by pre, to right in ltr context.">
 <style type='text/css'>
 .test { text-align: end; }

--- a/css-text-3/text-align/text-align-justify-001.html
+++ b/css-text-3/text-align/text-align-justify-001.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>text-align: justify, direction: rtl</title>
-<link rel='match' href='reference/text-align-justify-001.html'>
+<link rel='match' href='reference/text-align-justify-ref-001.html'>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the right.">

--- a/css-text-3/text-align/text-align-justify-002.html
+++ b/css-text-3/text-align/text-align-justify-002.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>text-align: justify, direction: ltr</title>
-<link rel='match' href='reference/text-align-justify-002.html'>
+<link rel='match' href='reference/text-align-justify-ref-002.html'>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the left.">

--- a/css-text-3/text-align/text-align-justify-003.html
+++ b/css-text-3/text-align/text-align-justify-003.html
@@ -5,7 +5,7 @@
 <title>text-align: justify, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justify-003.html'>
+<link rel='match' href='reference/text-align-justify-ref-003.html'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the right.">
 <style type='text/css'>
 .test { text-align: justify; }

--- a/css-text-3/text-align/text-align-justify-004.html
+++ b/css-text-3/text-align/text-align-justify-004.html
@@ -5,7 +5,7 @@
 <title>text-align: justify, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justify-004.html'>
+<link rel='match' href='reference/text-align-justify-ref-004.html'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the left.">
 <style type='text/css'>
 .test { text-align: justify; }

--- a/css-text-3/text-align/text-align-justify-005.html
+++ b/css-text-3/text-align/text-align-justify-005.html
@@ -5,7 +5,7 @@
 <title>text-align: justify, dir=auto, RTL first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justify-005.html'>
+<link rel='match' href='reference/text-align-justify-ref-005.html'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the right.">
 <style type='text/css'>
 .test { text-align: justify; }

--- a/css-text-3/text-align/text-align-justify-006.html
+++ b/css-text-3/text-align/text-align-justify-006.html
@@ -5,7 +5,7 @@
 <title>text-align: justify, dir=auto, LTR first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justify-006.html'>
+<link rel='match' href='reference/text-align-justify-ref-006.html'>
 <meta name="assert" content="text-align:justify aligns text in order to exactly fill the line box. Unless otherwise specified by text-align-last, the last line before a forced break or the end of the block is start-aligned – in this case, to the left.">
 <style type='text/css'>
 .test { text-align: justify; }

--- a/css-text-3/text-align/text-align-justifyall-001.html
+++ b/css-text-3/text-align/text-align-justifyall-001.html
@@ -5,7 +5,7 @@
 <title>text-align: justify-all, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justifyall-001.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-001.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>
 .test { text-align: justify-all; direction: rtl; }

--- a/css-text-3/text-align/text-align-justifyall-002.html
+++ b/css-text-3/text-align/text-align-justifyall-002.html
@@ -5,7 +5,7 @@
 <title>text-align: justify-all, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justifyall-002.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-002.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>
 .test { text-align: justify-all; direction: ltr; }

--- a/css-text-3/text-align/text-align-justifyall-003.html
+++ b/css-text-3/text-align/text-align-justifyall-003.html
@@ -5,7 +5,7 @@
 <title>text-align: justify-all, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justifyall-003.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-003.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>
 .test { text-align: justify-all; }

--- a/css-text-3/text-align/text-align-justifyall-004.html
+++ b/css-text-3/text-align/text-align-justifyall-004.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>text-align: justify-all, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel='match' href='reference/text-align-justifyall-004.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-004.html'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>

--- a/css-text-3/text-align/text-align-justifyall-005.html
+++ b/css-text-3/text-align/text-align-justifyall-005.html
@@ -5,7 +5,7 @@
 <title>text-align: justify-all, dir=auto, RTL first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justifyall-005.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-005.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>
 .test { text-align: justify-all; }

--- a/css-text-3/text-align/text-align-justifyall-006.html
+++ b/css-text-3/text-align/text-align-justifyall-006.html
@@ -5,7 +5,7 @@
 <title>text-align: justify-all, dir=auto, LTR first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-justifyall-006.html'>
+<link rel='match' href='reference/text-align-justifyall-ref-006.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
 <style type='text/css'>
 .test { text-align: justify-all; }

--- a/css-text-3/text-align/text-align-start-001.html
+++ b/css-text-3/text-align/text-align-start-001.html
@@ -5,7 +5,7 @@
 <title>text-align: start, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-001.html'>
+<link rel='match' href='reference/text-align-start-ref-001.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: start; direction: rtl; }

--- a/css-text-3/text-align/text-align-start-002.html
+++ b/css-text-3/text-align/text-align-start-002.html
@@ -5,7 +5,7 @@
 <title>text-align: start, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-002.html'>
+<link rel='match' href='reference/text-align-start-ref-002.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: start; direction: ltr; }

--- a/css-text-3/text-align/text-align-start-003.html
+++ b/css-text-3/text-align/text-align-start-003.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-003.html'>
+<link rel='match' href='reference/text-align-start-ref-003.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-004.html
+++ b/css-text-3/text-align/text-align-start-004.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-004.html'>
+<link rel='match' href='reference/text-align-start-ref-004.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-005.html
+++ b/css-text-3/text-align/text-align-start-005.html
@@ -5,7 +5,7 @@
 <title>text-align: start, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-005.html'>
+<link rel='match' href='reference/text-align-start-ref-005.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: start; direction: rtl; }

--- a/css-text-3/text-align/text-align-start-006.html
+++ b/css-text-3/text-align/text-align-start-006.html
@@ -5,7 +5,7 @@
 <title>text-align: start, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-006.html'>
+<link rel='match' href='reference/text-align-start-ref-006.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: start; direction: ltr; }

--- a/css-text-3/text-align/text-align-start-007.html
+++ b/css-text-3/text-align/text-align-start-007.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-007.html'>
+<link rel='match' href='reference/text-align-start-ref-007.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when direction is horizontal, rtl.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-008.html
+++ b/css-text-3/text-align/text-align-start-008.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-008.html'>
+<link rel='match' href='reference/text-align-start-ref-008.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is horizontal, ltr.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-009.html
+++ b/css-text-3/text-align/text-align-start-009.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=auto, RTL first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-009.html'>
+<link rel='match' href='reference/text-align-start-ref-009.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when direction is auto and first strong character is rtl.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-010.html
+++ b/css-text-3/text-align/text-align-start-010.html
@@ -5,7 +5,7 @@
 <title>text-align: start, dir=auto, LTR first strong</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-010.html'>
+<link rel='match' href='reference/text-align-start-ref-010.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is auto and first strong character is ltr.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-014.html
+++ b/css-text-3/text-align/text-align-start-014.html
@@ -5,7 +5,7 @@
 <title>text-align: start, pre, dir=rtl inherited</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-014.html'>
+<link rel='match' href='reference/text-align-start-ref-014.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. right when base direction is rtl.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-015.html
+++ b/css-text-3/text-align/text-align-start-015.html
@@ -5,7 +5,7 @@
 <title>text-align: start, pre, dir=ltr inherited</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-015.html'>
+<link rel='match' href='reference/text-align-start-ref-015.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when base  direction is  ltr.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-016.html
+++ b/css-text-3/text-align/text-align-start-016.html
@@ -5,7 +5,7 @@
 <title>text-align: start, pre, dir=auto</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-016.html'>
+<link rel='match' href='reference/text-align-start-ref-016.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. left when direction is auto and first strong character is ltr, and right when first strong is rtl.">
 <style type='text/css'>
 .test { text-align: start; }

--- a/css-text-3/text-align/text-align-start-017.html
+++ b/css-text-3/text-align/text-align-start-017.html
@@ -5,7 +5,7 @@
 <title>text-align: start, pre, dir=auto on surrounding block</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
-<link rel='match' href='reference/text-align-start-017.html'>
+<link rel='match' href='reference/text-align-start-ref-017.html'>
 <meta name="assert" content="text-align:start aligns inline-level content to the start edge of the line box – ie. since dir=auto is not inherited by pre, to left in ltr context.">
 <style type='text/css'>
 .test { text-align: start; }


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/896)
<!-- Reviewable:end -->
