### PR TITLE
[css-flexbox-1] Fix broken rel="help" anchors

### DIFF
--- a/css-flexbox-1/flexbox_rtl-flow-reverse.html
+++ b/css-flexbox-1/flexbox_rtl-flow-reverse.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <link rel="match" href="flexbox_rtl-flow-reverse-ref.html">
 <style>
 div {

--- a/css-flexbox-1/flexbox_rtl-flow.html
+++ b/css-flexbox-1/flexbox_rtl-flow.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <link rel="match" href="flexbox_rtl-flow-ref.html">
 <style>
 div {

--- a/css-flexbox-1/flexbox_rtl-order.html
+++ b/css-flexbox-1/flexbox_rtl-order.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <link rel="match" href="flexbox_rtl-order-ref.html">
 <style>
 div {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-nowrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-nowrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-wrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap-reverse.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-nowrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row-reverse nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-nowrap">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row-reverse wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row-reverse wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap-reverse">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
 <meta name="flags" content="dom">
 <style>

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
@@ -3,7 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: row</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-row">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-wrap.html
+++ b/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-wrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | computed style | flex-flow: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <meta name="flags" content="dom">
 <style>
 body {

--- a/css-flexbox-1/ttwf-reftest-flex-inline.html
+++ b/css-flexbox-1/ttwf-reftest-flex-inline.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Flexible Box Test: display proprety - inline-flex</title>
     <link rel="author" title="haosdent" href="mailto:haosdent@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valuedef-inline-flex">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-display-inline-flex">
     <link rel="match" href="reference/ttwf-reftest-flex-inline-ref.html">
     <meta name="assert" content="Statement describing what the test case is asserting">
     <style type="text/css">


### PR DESCRIPTION
Fixes various `Test links to unknown specification anchor:` warnings in the Travis build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/899)
<!-- Reviewable:end -->
