### PR TITLE
[css-flexbox-1] Fix reference for flex-items-flexibility.html

### DIFF
--- a/css-flexbox-1/reference/flex-items-flexibility.html
+++ b/css-flexbox-1/reference/flex-items-flexibility.html
@@ -5,9 +5,6 @@
 		<link rel="author" title="Chunsheng Zhang" href="mailto:zhangcs_423@163.com" />
 		<style type="text/css">
 			#container {
-				display: flex;
-				justify-content: center;
-				align-items: center;
 				border: 5px solid green;
 				width: 600px;
 				height: 200px;
@@ -17,22 +14,16 @@
 				top: 70px;
 				left: 10px;
 			}
-			div {
-				padding: 10px;
-				width: 30px;
-				height: 40px;
-				text-align: center;
-				flex: 1 0 auto;
-			}
 			#flex {
 				border: 2px dotted blue;
 				background: green;
 				border-radius: 3px;
-				flex: 2 0 auto;
 				position: absolute;
-				top: 70px;
-				left: 160px;
-				width: 254px;
+				top: 73px;
+				left: 166.5px;
+				width: 253px;
+                height: 40px;
+                padding: 10px;
 			}
 		</style>
 	</head>
@@ -40,9 +31,7 @@
 		<p>This case tests that flex items flexibility</p>
 		<p>The test passes if there is no red</p>
 		<section id="container">
-			<div></div>
 			<div id="flex"></div>
-			<div></div>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
The math was wrong in this testcase. In addition, I have cleaned up this
testcase not to rely on display: flex itself, and removed unnecessary elements.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/901)
<!-- Reviewable:end -->
