### PR TITLE
[css-ui-3] Fix broken rel="help" anchors

### DIFF
--- a/css-ui-3/text-overflow.html
+++ b/css-ui-3/text-overflow.html
@@ -4,7 +4,7 @@
     <link rel="author" title="YreenChan" href="mailto:yreenchan@gmail.com">
     <link rel="reviewer" title="Simon Pieters" href="mailto:simonp@opera.com">
     <link rel="reviewer" title="Leif Arne Storset" href="mailto:lstorset@opera.com">
-    <link rel="help" href="http://www.w3.org/TR/css3-ui/#text-overflow0" title="8.2. the 'text-overflow' property">
+    <link rel="help" href="http://www.w3.org/TR/css3-ui/#text-overflow" title="8.2. the 'text-overflow' property">
     <link rel="match" href="text-overflow-ref.html">
     <meta name="flags" content="font ahem">
     <meta name="assert" content="'text-overflow:ellipsis' renders U+2026 when text is overflowing.">

--- a/css-ui-3/zcorpan/box-sizing-padding-box-block-001.html
+++ b/css-ui-3/zcorpan/box-sizing-padding-box-block-001.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>CSS UI: box-sizing:padding-box for a block box</title>
-<link rel="help" href="http://www.w3.org/TR/css3-ui/#box-sizing0">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#box-sizing">
 <link rel="match" href="box-sizing-padding-box-block-001-ref.html">
 <style>
  #test { box-sizing:padding-box; padding:50px; width:150px; height:50px; background:black }

--- a/css-ui-3/zcorpan/guide.txt
+++ b/css-ui-3/zcorpan/guide.txt
@@ -3,7 +3,7 @@ work the same.
 
 First find a feature you want to test.
 
-https://drafts.csswg.org/css-ui/#box-sizing0
+https://drafts.csswg.org/css-ui/#box-sizing
 [[ 
 padding-box
 The specified width and height (and respective min/max properties) on this element determine the


### PR DESCRIPTION
Fixes a few `Test links to unknown specification anchor:` warnings in the Travis build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/906)
<!-- Reviewable:end -->
