### PR TITLE
[cssom-1] Fix broken rel="help" anchors

### DIFF
--- a/cssom-1/css-style-declaration-modifications.html
+++ b/cssom-1/css-style-declaration-modifications.html
@@ -15,8 +15,8 @@
 {
   "CSSStyleDeclaration_accessible": {
     "help": ["http://www.w3.org/TR/cssom/#the-cssstylesheet-interface",
-             "http://www.w3.org/TR/cssom/#the-cssrulelist-sequence",
-             "http://www.w3.org/TR/cssom/#css-style-rule-rule-set"],
+             "http://www.w3.org/TR/cssom/#the-cssrulelist-interface",
+             "http://www.w3.org/TR/cssom/#the-cssstylerule-interface"],
     "assert": "Can access CSSStyleDeclaration through CSSOM"
   },
   "read": { "assert": "initial property values are correct" },
@@ -47,8 +47,8 @@
        declaration = styleElement.sheet.cssRules.item(0).style;
      }, "CSSStyleDeclaration_accessible",
      {  help: [ "http://www.w3.org/TR/cssom/#the-cssstylesheet-interface",
-                "http://www.w3.org/TR/cssom/#the-cssrulelist-sequence",
-                "http://www.w3.org/TR/cssom/#css-style-rule-rule-set" ],
+                "http://www.w3.org/TR/cssom/#the-cssrulelist-interface",
+                "http://www.w3.org/TR/cssom/#the-cssstylerule-interface" ],
         assert: "Can access CSSStyleDeclaration through CSSOM" });
 
     test(function() {        

--- a/cssom-1/cssimportrule.html
+++ b/cssom-1/cssimportrule.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Letitia Lew" href="mailto:lew.letitia@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/cssom/#css-rules">
     <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssrule-interface">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#css-import-rule">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssimportrule-interface">
     <meta name="flags" content="dom">
     <meta name="assert" content="All properties for this CSSImportRule instance of CSSRule are initialized correctly"> 
     <script src="/resources/testharness.js"></script>

--- a/cssom-1/cssstylerule.html
+++ b/cssom-1/cssstylerule.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Letitia Lew" href="mailto:lew.letitia@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/cssom/#css-rules">
     <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssrule-interface">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#css-style-rule-rule-set">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssstylerule-interface">
     <meta name="flags" content="dom">
     <meta name="assert" content="All properties for this CSSStyleRule instance of CSSRule are initialized correctly"> 
     <script src="/resources/testharness.js"></script>

--- a/cssom-1/index-003.html
+++ b/cssom-1/index-003.html
@@ -2,7 +2,7 @@
 <head>
   <title>CSS OM: CSS Values</title>
   <link rel="author" title="Divya Manian" href="mailto:manian@adobe.com">
-  <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssrulelist-sequence">
+  <link rel="help" href="http://www.w3.org/TR/cssom/#the-cssrulelist-interface">
   <meta name="flags" content="dom">
   <meta name="assert" content="Testing Serialization of Style Rules">
   <script src="/resources/testharness.js"></script>

--- a/cssom-1/style-sheet-interfaces-001.html
+++ b/cssom-1/style-sheet-interfaces-001.html
@@ -3,7 +3,7 @@
  <head>
   <title>CSS Test: CSSOM StyleSheet Initial Values</title>
   <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
-  <link rel="help" href="http://www.w3.org/TR/cssom/#style-sheet-0">
+  <link rel="help" href="http://www.w3.org/TR/cssom/#css-style-sheets">
   <meta name="flags" content="dom">
   <meta name="assert" content="StyleSheet and CSSStyleSheet objects have the properties specified in their interfaces">
   <script src="/resources/testharness.js" type="text/javascript"></script>
@@ -27,7 +27,7 @@
                "ownerRule, cssRules are read only"]
   },
   "CSSStyleSheet_property_values": {
-    "help": ["http://www.w3.org/TR/cssom/#style-sheet-0",
+    "help": ["http://www.w3.org/TR/cssom/#css-style-sheets",
              "http://www.w3.org/TR/cssom/#cssimportrule"],
     "assert": "CSSStyleSheet initial property values are correct"
   },
@@ -80,7 +80,7 @@
         assert_true(styleSheet.cssRules.item(0) instanceof CSSImportRule);
         importSheet = styleSheet.cssRules.item(0).styleSheet;
     }, "CSSStyleSheet_property_values",
-    { help: [ "http://www.w3.org/TR/cssom/#style-sheet-0", 
+    { help: [ "http://www.w3.org/TR/cssom/#css-style-sheets",
     		  "http://www.w3.org/TR/cssom/#cssimportrule" ],
       assert: "CSSStyleSheet initial property values are correct" });
 

--- a/cssom-1/ttwf-cssom-doc-ext-load-count.html
+++ b/cssom-1/ttwf-cssom-doc-ext-load-count.html
@@ -4,8 +4,8 @@
     <title>CSSOM - Extensions to the Document Interface: StyleSheetList length reflects dynamically loaded and unloaded sheets</title>
     <link rel="author" title="Jesse Bounds" href="mailto:jesse@codeforamerica.org">
     <link rel="help" href="http://www.w3.org/TR/cssom/#extensions-to-the-document-interface">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-sequence">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#style-sheet-collections">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-interface">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#css-style-sheet-collections">
     <link rel="stylesheet" href="stylesheet.css" type="text/css">
     <meta name="flags" content="dom">
     <meta name="assert" content="The styleSheets length attribute must reflect the number of sheets at page load and after dynamically">

--- a/cssom-1/ttwf-cssom-doc-ext-load-tree-order.html
+++ b/cssom-1/ttwf-cssom-doc-ext-load-tree-order.html
@@ -4,8 +4,8 @@
     <title>CSSOM -  Extensions to the Document Interface: Stylesheet header load order</title>
     <link rel="author" title="Jesse Bounds" href="mailto:jesse@codeforamerica.org">
     <link rel="help" href="http://www.w3.org/TR/cssom/#extensions-to-the-document-interface">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-sequence">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#style-sheet-collections">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-interface">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#css-style-sheet-collections">
     <style title="aaa" type="text/css">
       H1 {border-width: 1; border: solid; text-align: center}
     </style>

--- a/cssom-1/ttwf-cssom-document-extension.html
+++ b/cssom-1/ttwf-cssom-document-extension.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Jesse Bounds" href="mailto:jesse@codeforamerica.org">
     <link rel="reviewer" title="Ms2ger" href="mailto:ms2ger@gmail.com"> <!-- 2012-06-17 -->
     <link rel="help" href="http://www.w3.org/TR/cssom/#extensions-to-the-document-interface">
-    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-sequence">
+    <link rel="help" href="http://www.w3.org/TR/cssom/#the-stylesheetlist-interface">
     <meta name="flags" content="dom">
     <meta name="assert" content="The styleSheets attribute must return a StyleSheetList sequence representing the document style sheets.">
     <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
Fixes a few `Test links to unknown specification anchor: warnings` in the Travis build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/907)
<!-- Reviewable:end -->
