### PR TITLE
Fix tools/travis/build.py:get_new_commits() when there aren't any new commits

### DIFF
--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -131,7 +131,10 @@ def get_new_commits():
         prev_commit = f.read().strip()
 
     commit_range = "%s..%s" % (prev_commit, os.environ['TRAVIS_COMMIT'])
-    return reversed(git("log", "--pretty=%H", "-r", commit_range).strip().split("\n"))
+    commits = git("log", "--pretty=%H", "-r", commit_range).strip()
+    if not commits:
+        return []
+    return reversed(commits.split("\n"))
 
 def maybe_push():
     if os.environ["TRAVIS_PULL_REQUEST"] != "false":


### PR DESCRIPTION
Return `[]` instead of `['']` as the list of new commits in said case.

Refs:
* https://github.com/w3c/csswg-test/pull/908#issuecomment-147879105
* https://travis-ci.org/w3c/csswg-test/builds/85227540

CC: @jgraham

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/918)
<!-- Reviewable:end -->
