### PR TITLE
[css-grid] Fix test for flexible lengths under 1

### DIFF
--- a/css-grid-1/grid-definition/grid-inline-support-flexible-lengths-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-flexible-lengths-001.xht
@@ -34,10 +34,10 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "2fr", "2fr", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "10fr", "10fr", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "10fr", "10fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "0.5fr", "0.5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "800px", "600px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "0.5fr", "0.5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");

--- a/css-grid-1/grid-definition/grid-support-flexible-lengths-001.xht
+++ b/css-grid-1/grid-definition/grid-support-flexible-lengths-001.xht
@@ -34,10 +34,10 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "2fr", "2fr", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "10fr", "10fr", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "10fr", "10fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "0.5fr", "0.5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "800px", "600px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "0.5fr", "0.5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "400px", "300px");
+            TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");


### PR DESCRIPTION
The spec now says (http://www.w3.org/TR/css-grid-1/#flex-factor-sum):
"Let flex factor sum be the sum of the flex factors of the flexible
tracks. If this value is less than 1, set it to 1 instead."

This means that flexible tracks under 1fr will have a special behavior.
Updated the tests to follow this new behavior.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/953)
<!-- Reviewable:end -->
