### PR TITLE
[css-grid] Fix inline grid tests to avoid weird spaces

### DIFF
--- a/css-grid-1/grid-items/grid-inline-items-001.xht
+++ b/css-grid-1/grid-items/grid-inline-items-001.xht
@@ -20,7 +20,6 @@
                 display: inline-grid;
                 font: 25px/1 Ahem;
                 color: green;
-                grid-template-columns: auto auto;
             }
         ]]></style>
     </head>
@@ -33,9 +32,7 @@
             em
             <div>it</div>
             em
-        </div>
-        <br />
-        <div class="test-inline-grid-overlapping-green">
+        </div><div class="test-inline-grid-overlapping-green">
             it
             <span>em</span>
             it

--- a/css-grid-1/grid-items/grid-inline-items-002.xht
+++ b/css-grid-1/grid-items/grid-inline-items-002.xht
@@ -21,17 +21,13 @@
                 font: 25px/1 Ahem;
                 color: green;
             }
-
-            .two-columns {
-                grid-template-columns: auto auto;
-            }
         ]]></style>
     </head>
     <body>
         <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
         <div id="reference-overlapped-red"></div>
-        <div class="test-inline-grid-overlapping-green two-columns">
+        <div class="test-inline-grid-overlapping-green">
             <div>
                 <div>it</div>
                 em
@@ -40,14 +36,18 @@
                 it
                 <div>em</div>
             </div>
-        </div>
-        <br />
-        <div class="test-inline-grid-overlapping-green">
+        </div><div class="test-inline-grid-overlapping-green">
             <span>
-                <span>it</span>em
+                <span>i</span>t
             </span>
             <span>
-                it<span>em</span>
+                e<span>m</span>
+            </span>
+            <span>
+                <span>i</span>t
+            </span>
+            <span>
+                e<span>m</span>
             </span>
         </div>
 


### PR DESCRIPTION
Some space were added due to the break in the tests using inline grids.

Change the tests to avoid the break and fix the issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/955)
<!-- Reviewable:end -->
