### PR TITLE
Improve CSSOM tests.

### DIFF
--- a/cssom-1/css-style-declaration-modifications.html
+++ b/cssom-1/css-style-declaration-modifications.html
@@ -11,87 +11,53 @@
   <style id="styleElement">
       #test { color: green; }
   </style>
-  <script id="metadata_cache">/*
-{
-  "CSSStyleDeclaration_accessible": {
-    "help": ["http://www.w3.org/TR/cssom/#the-cssstylesheet-interface",
-             "http://www.w3.org/TR/cssom/#the-cssrulelist-interface",
-             "http://www.w3.org/TR/cssom/#the-cssstylerule-interface"],
-    "assert": "Can access CSSStyleDeclaration through CSSOM"
-  },
-  "read": { "assert": "initial property values are correct" },
-  "csstext_write": {
-    "assert": ["setting cssText adds new properties",
-               "setting cssText removes existing properties",
-               "properties set through cssText are reflected in the computed style"]
-  },
-  "property_write": {
-    "assert": ["setProperty adds new properties",
-               "properties set through setProperty are reflected in the computed style"]
-  }
-}
-*/</script>
  </head>
  <body>
- <noscript>Test not run - javascript required.</noscript>
  <div id="log"></div>
  <div id="test"></div>
  <script type="text/javascript">
-    var styleElement = document.getElementById("styleElement");
-    var styleDeclaration;
-    test(function() {
-       assert_own_property(styleElement, "sheet");
-       assert_own_property(styleElement.sheet, "cssRules");
-       assert_true(styleElement.sheet.cssRules instanceof CSSRuleList);
-       assert_true(styleElement.sheet.cssRules.item(0) instanceof CSSStyleRule);
-       declaration = styleElement.sheet.cssRules.item(0).style;
-     }, "CSSStyleDeclaration_accessible",
-     {  help: [ "http://www.w3.org/TR/cssom/#the-cssstylesheet-interface",
-                "http://www.w3.org/TR/cssom/#the-cssrulelist-interface",
-                "http://www.w3.org/TR/cssom/#the-cssstylerule-interface" ],
-        assert: "Can access CSSStyleDeclaration through CSSOM" });
+    var declaration;
+    setup(function() {
+        var styleElement = document.getElementById("styleElement");
+        declaration = styleElement.sheet.cssRules.item(0).style;
+    });
 
-    test(function() {        
-        assert_regexp_match(declaration.cssText, /color: green;\s*/);
+    test(function() {
+        assert_equals(declaration.cssText, "color: green;");
         assert_equals(declaration.getPropertyValue("color"), "green");
-    }, "read",
-    { assert: "initial property values are correct" });
+    }, "Reading CSSStyleDeclaration initialized from a style element");
 
     test(function() {
-        declaration.cssText = "margin-left: 10px; padding-left: 10px;";
-        assert_regexp_match(declaration.cssText, /margin-left: 10px;\s+padding-left: 10px;\s+/);
+        declaration.cssText = "margin-left:10px;  padding-left:10px";
+        assert_equals(declaration.cssText, "margin-left: 10px; padding-left: 10px;");
         assert_equals(declaration.length, 2);
         assert_equals(declaration.item(0), "margin-left");
         assert_equals(declaration.item(1), "padding-left");
         assert_equals(declaration.getPropertyValue("margin-left"), "10px");
         assert_equals(declaration.getPropertyValue("padding-left"), "10px");
-        
+
         var computedStyle = window.getComputedStyle(document.getElementById("test"));
         assert_equals(computedStyle.getPropertyValue("margin-left"), "10px");
         assert_equals(computedStyle.getPropertyValue("padding-left"), "10px");
-    }, "csstext_write",
-    { assert: [ "setting cssText adds new properties",
-                "setting cssText removes existing properties",
-                "properties set through cssText are reflected in the computed style"] });
+    }, "Setting CSSStyleDeclaration#cssText");
 
     test(function() {
-        while(declaration.length > 0)
+        while (declaration.length > 0) {
             declaration.removeProperty(declaration.item(0));
+        }
         declaration.setProperty("margin-left", "15px");
         declaration.setProperty("padding-left", "15px");
-        
+
         assert_equals(declaration.length, 2);
         assert_equals(declaration.item(0), "margin-left");
         assert_equals(declaration.item(1), "padding-left");
         assert_equals(declaration.getPropertyValue("margin-left"), "15px");
         assert_equals(declaration.getPropertyValue("padding-left"), "15px");
-        
+
         var computedStyle = window.getComputedStyle(document.getElementById("test"));
         assert_equals(computedStyle.getPropertyValue("margin-left"), "15px");
         assert_equals(computedStyle.getPropertyValue("padding-left"), "15px");
-    }, "property_write",
-    { assert: [ "setProperty adds new properties", 
-                "properties set through setProperty are reflected in the computed style"] });    
+    }, "Calling CSSStyleDeclaration#setProperty");
  </script>
  </body>
 </html>

--- a/cssom-1/cssimportrule.html
+++ b/cssom-1/cssimportrule.html
@@ -15,43 +15,25 @@
     	@import url("support/a-green.css");
     	@import url("support/a-green.css") screen;
     </style>
-
-    <script id="metadata_cache">/*
-{
-  "CSSRule and CSSImportRule types": { "assert": "rule is an instance of CSSRule and CSSImportRule" },
-  "Rule_type_property": { "assert": "CSSRule type property has correct type and constants" },
-  "CSSRule_properties": {
-    "assert": ["cssText, parentRule, parentStyleSheet properties exist on CSSRule",
-               "type, parentRule, parentStyleSheet properties on CSSRule are readonly"]
-  },
-  "CSSRule_properties_values": { "assert": "type, parentRule, parentStyleSheet initial property values on CSSRule are correct" },
-  "CSSImportRule_properties": {
-    "assert": ["href, media, styleSheet properties exist on CSSImportsRule",
-               "href, media, styleSheet properties are readonly"]
-  },
-  "CSSImportRule_properties_values": { "assert": "Initial values of href, media, styleSheet properties on CSSImportRule are correct" }
-}
-*/</script>
 </head>
 <body>
-	<noscript>Test not run -- JavaScript required.</noscript>
 	<div id="log"></div>
 
 	<script type="text/javascript">
-		var styleSheet = document.getElementById("styleElement").sheet;
-		var ruleList = styleSheet.cssRules;
-
-		var rule = ruleList[0];
-		var ruleWithMedia = ruleList[1];
+		var rule, ruleWithMedia;
+		setup(function() {
+			var styleSheet = document.getElementById("styleElement").sheet;
+			var ruleList = styleSheet.cssRules;
+			rule = ruleList[0];
+			ruleWithMedia = ruleList[1];
+		});
 
 		test(function() {
 			assert_true(rule instanceof CSSRule);
 			assert_true(rule instanceof CSSImportRule);
 			assert_true(ruleWithMedia instanceof CSSRule);
 			assert_true(ruleWithMedia instanceof CSSImportRule);
-		}, "CSSRule and CSSImportRule types",
-		{ assert: "rule is an instance of CSSRule and CSSImportRule" }
-		);
+		}, "CSSRule and CSSImportRule types");
 
 		test(function() {
 			assert_equals(rule.STYLE_RULE, 1);
@@ -60,47 +42,39 @@
 			assert_equals(rule.FONT_FACE_RULE, 5);
 			assert_equals(rule.PAGE_RULE, 6);
 			assert_equals(rule.NAMESPACE_RULE, 10);
-			assert_own_property(rule, "type");
-			assert_true(typeof rule.type === "number");
-		}, "Rule_type_property",
-		{ assert: "CSSRule type property has correct type and constants" }
-		);
+			assert_idl_attribute(rule, "type");
+			assert_equals(typeof rule.type, "number");
+		}, "Type of CSSRule#type and constant values");
 
 		test(function() {
 			assert_true(rule instanceof CSSRule);
-			assert_own_property(rule, "cssText");
-			assert_own_property(rule, "parentRule");
-			assert_own_property(rule, "parentStyleSheet");
+			assert_idl_attribute(rule, "cssText");
+			assert_idl_attribute(rule, "parentRule");
+			assert_idl_attribute(rule, "parentStyleSheet");
 
 			assert_readonly(rule, "type");
 			assert_readonly(rule, "parentRule");
 			assert_readonly(rule, "parentStyleSheet");
-		}, "CSSRule_properties",
-		{ assert: ["cssText, parentRule, parentStyleSheet properties exist on CSSRule", "type, parentRule, parentStyleSheet properties on CSSRule are readonly"] }
-		);
+		}, "Existence and writability of CSSRule attributes");
 
 		test(function() {
 			assert_equals(rule.type, rule.IMPORT_RULE);
 			assert_equals(typeof rule.cssText, "string");
-			assert_equals(rule.cssText, "@import url(\"cssimportrule.css\");");
-			assert_equals(ruleWithMedia.cssText, "@import url(\"cssimportrule.css\") screen;");
+			assert_equals(rule.cssText, '@import url("support/a-green.css");');
+			assert_equals(ruleWithMedia.cssText, '@import url("support/a-green.css") screen;');
 			assert_equals(rule.parentRule, null);
 			assert_true(rule.parentStyleSheet instanceof CSSStyleSheet);
-		}, "CSSRule_properties_values",
-		{ assert: "type, parentRule, parentStyleSheet initial property values on CSSRule are correct" }
-		);
+		}, "Values of CSSRule attributes");
 
 		test(function() {
-			assert_own_property(rule, "href");
-			assert_own_property(rule, "media");
-			assert_own_property(rule, "styleSheet");
+			assert_idl_attribute(rule, "href");
+			assert_idl_attribute(rule, "media");
+			assert_idl_attribute(rule, "styleSheet");
 
 			assert_readonly(rule, "href");
 			assert_readonly(rule, "media");
 			assert_readonly(rule, "styleSheet");
-		}, "CSSImportRule_properties",
-		{ assert: ["href, media, styleSheet properties exist on CSSImportsRule", "href, media, styleSheet properties are readonly"] }
-		);
+		}, "Existence and writability of CSSImportRule attributes");
 
 		test(function() {
 			assert_equals(typeof rule.href, "string");
@@ -108,10 +82,7 @@
 			assert_true(rule.styleSheet instanceof CSSStyleSheet);
 			assert_true(ruleWithMedia.media.length > 0);
 			assert_equals(ruleWithMedia.media.mediaText, "screen");
-		}, "CSSImportRule_properties_values",
-		{ assert: "Initial values of href, media, styleSheet properties on CSSImportRule are correct" }
-		);
-
+		}, "Values of CSSImportRule attributes");
 	</script>
 </body>
 </html>


### PR DESCRIPTION
This removes incorrect assertions (IDL attributes do not correspond to 'own'
properties), tightens serialization requirements (to match the specification
and both Gecko and Chrome), and removes some unnecessary cruft.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/962)
<!-- Reviewable:end -->
