### PR TITLE
Move the DOMPoint test a little closer to the specification.

### DIFF
--- a/geometry-1/DOMPoint-001.html
+++ b/geometry-1/DOMPoint-001.html
@@ -63,7 +63,7 @@
             checkDOMPoint(new DOMPoint({x:1, z:3}), {x:1, y:0, z:3, w:1});
         },'testConstructorDOMPoint');
         test(function() {
-            checkDOMPoint(new DOMPoint(1, undefined), {x:1, y:NaN, z:0, w:1});
+            checkDOMPoint(new DOMPoint(1, undefined), {x:1, y:0, z:0, w:1});
         },'testConstructor2undefined');
         test(function() {
             checkDOMPoint(new DOMPoint("a", "b"), {x:NaN, y:NaN, z:0, w:1});


### PR DESCRIPTION
Note that there are still a large number of bugs remaining in this tests,
like testing constructor overloads that take dictionaries that no longer
exist in the specification.

Fixes #968.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/969)
<!-- Reviewable:end -->
