### PR TITLE
Revert "Remove trailing whitespace" for white-space tests

### DIFF
--- a/css-text-3/white-space/seg-break-transformation-000.html
+++ b/css-text-3/white-space/seg-break-transformation-000.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>hello
 there</span></div>
-<div id='test2' class="test"><span>hello
+<div id='test2' class="test"><span>hello   
 there</span></div>
 <div id='test3' class="test"><span>hello
         there</span></div>
-<div id='test4' class="test"><span>hello
+<div id='test4' class="test"><span>hello   
      there</span></div>
 <div id='test5' class="test"><span>hello
 
 
 there</span></div>
-<div id='test6' class="test"><span>hello
-
-
+<div id='test6' class="test"><span>hello  
+   
+   
    there</span></div>
 <div id="ref" class="ref"><span>hello there</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-001.html
+++ b/css-text-3/white-space/seg-break-transformation-001.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>日本語
 中国话</span></div>
-<div id='test2' class="test"><span>日本語
+<div id='test2' class="test"><span>日本語   
 中国话</span></div>
 <div id='test3' class="test"><span>日本語
         中国话</span></div>
-<div id='test4' class="test"><span>日本語
+<div id='test4' class="test"><span>日本語   
      中国话</span></div>
 <div id='test5' class="test"><span>日本語
 
 
 中国话</span></div>
-<div id='test6' class="test"><span>日本語
-
-
+<div id='test6' class="test"><span>日本語  
+   
+   
    中国话</span></div>
 <div id="ref" class="ref"><span>日本語中国话</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-002.html
+++ b/css-text-3/white-space/seg-break-transformation-002.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ＦＵＬＬ
 ＷＩＤＴＨ</span></div>
-<div id='test2' class="test"><span>ＦＵＬＬ
+<div id='test2' class="test"><span>ＦＵＬＬ   
 ＷＩＤＴＨ</span></div>
 <div id='test3' class="test"><span>ＦＵＬＬ
         ＷＩＤＴＨ</span></div>
-<div id='test4' class="test"><span>ＦＵＬＬ
+<div id='test4' class="test"><span>ＦＵＬＬ   
      ＷＩＤＴＨ</span></div>
 <div id='test5' class="test"><span>ＦＵＬＬ
 
 
 ＷＩＤＴＨ</span></div>
-<div id='test6' class="test"><span>ＦＵＬＬ
-
-
+<div id='test6' class="test"><span>ＦＵＬＬ  
+   
+   
    ＷＩＤＴＨ</span></div>
 <div id="ref" class="ref"><span>ＦＵＬＬＷＩＤＴＨ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-003.html
+++ b/css-text-3/white-space/seg-break-transformation-003.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ﾊﾝ
 ｶｸ</span></div>
-<div id='test2' class="test"><span>ﾊﾝ
+<div id='test2' class="test"><span>ﾊﾝ   
 ｶｸ</span></div>
 <div id='test3' class="test"><span>ﾊﾝ
         ｶｸ</span></div>
-<div id='test4' class="test"><span>ﾊﾝ
+<div id='test4' class="test"><span>ﾊﾝ   
      ｶｸ</span></div>
 <div id='test5' class="test"><span>ﾊﾝ
 
 
 ｶｸ</span></div>
-<div id='test6' class="test"><span>ﾊﾝ
-
-
+<div id='test6' class="test"><span>ﾊﾝ  
+   
+   
    ｶｸ</span></div>
 <div id="ref" class="ref"><span>ﾊﾝｶｸ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-004.html
+++ b/css-text-3/white-space/seg-break-transformation-004.html
@@ -18,36 +18,36 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>₩
 ２４</span></div>
-<div id='test2' class="test"><span>₩
+<div id='test2' class="test"><span>₩   
 ２４</span></div>
 <div id='test3' class="test"><span>₩
         ２４</span></div>
-<div id='test4' class="test"><span>₩
+<div id='test4' class="test"><span>₩   
      ２４</span></div>
 <div id='test5' class="test"><span>₩
 
 
 ２４</span></div>
-<div id='test6' class="test"><span>₩
-
-
+<div id='test6' class="test"><span>₩  
+   
+   
    ２４</span></div>
 <div id="ref1" class="ref"><span>₩２４</span></div>
 <div id='test7' class="test"><span>２４
 ₩</span></div>
-<div id='test8' class="test"><span>２４
+<div id='test8' class="test"><span>２４   
 ₩</span></div>
 <div id='test9' class="test"><span>２４
         ₩</span></div>
-<div id='test10' class="test"><span>２４
+<div id='test10' class="test"><span>２４   
      ₩</span></div>
 <div id='test11' class="test"><span>２４
 
 
 ₩</span></div>
-<div id='test12' class="test"><span>２４
-
-
+<div id='test12' class="test"><span>２４  
+   
+   
    ₩</span></div>
 <div id="ref2" class="ref"><span>２４₩</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-005.html
+++ b/css-text-3/white-space/seg-break-transformation-005.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>漢字
 kanji</span></div>
-<div id='test2' class="test"><span>漢字
+<div id='test2' class="test"><span>漢字   
 kanji</span></div>
 <div id='test3' class="test"><span>漢字
         kanji</span></div>
-<div id='test4' class="test"><span>漢字
+<div id='test4' class="test"><span>漢字   
      kanji</span></div>
 <div id='test5' class="test"><span>漢字
 
 
 kanji</span></div>
-<div id='test6' class="test"><span>漢字
-
-
+<div id='test6' class="test"><span>漢字  
+   
+   
    kanji</span></div>
 <div id="ref" class="ref"><span>漢字 kanji</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-006.html
+++ b/css-text-3/white-space/seg-break-transformation-006.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ＦＵＬＬ
 width</span></div>
-<div id='test2' class="test"><span>ＦＵＬＬ
+<div id='test2' class="test"><span>ＦＵＬＬ   
 width</span></div>
 <div id='test3' class="test"><span>ＦＵＬＬ
         width</span></div>
-<div id='test4' class="test"><span>ＦＵＬＬ
+<div id='test4' class="test"><span>ＦＵＬＬ   
      width</span></div>
 <div id='test5' class="test"><span>ＦＵＬＬ
 
 
 width</span></div>
-<div id='test6' class="test"><span>ＦＵＬＬ
-
-
+<div id='test6' class="test"><span>ＦＵＬＬ  
+   
+   
    width</span></div>
 <div id="ref" class="ref"><span>ＦＵＬＬ width</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-007.html
+++ b/css-text-3/white-space/seg-break-transformation-007.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>han
 ｶｸ</span></div>
-<div id='test2' class="test"><span>han
+<div id='test2' class="test"><span>han   
 ｶｸ</span></div>
 <div id='test3' class="test"><span>han
         ｶｸ</span></div>
-<div id='test4' class="test"><span>han
+<div id='test4' class="test"><span>han   
      ｶｸ</span></div>
 <div id='test5' class="test"><span>han
 
 
 ｶｸ</span></div>
-<div id='test6' class="test"><span>han
-
-
+<div id='test6' class="test"><span>han  
+   
+   
    ｶｸ</span></div>
 <div id="ref" class="ref"><span>han ｶｸ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-008.html
+++ b/css-text-3/white-space/seg-break-transformation-008.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>日本語
 ＷＩＤＴＨ</span></div>
-<div id='test2' class="test"><span>日本語
+<div id='test2' class="test"><span>日本語   
 ＷＩＤＴＨ</span></div>
 <div id='test3' class="test"><span>日本語
         ＷＩＤＴＨ</span></div>
-<div id='test4' class="test"><span>日本語
+<div id='test4' class="test"><span>日本語   
      ＷＩＤＴＨ</span></div>
 <div id='test5' class="test"><span>日本語
 
 
 ＷＩＤＴＨ</span></div>
-<div id='test6' class="test"><span>日本語
-
-
+<div id='test6' class="test"><span>日本語  
+   
+   
    ＷＩＤＴＨ</span></div>
 <div id="ref" class="ref"><span>日本語ＷＩＤＴＨ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-009.html
+++ b/css-text-3/white-space/seg-break-transformation-009.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ＦＵＬＬ
 ｶｸ</span></div>
-<div id='test2' class="test"><span>ＦＵＬＬ
+<div id='test2' class="test"><span>ＦＵＬＬ   
 ｶｸ</span></div>
 <div id='test3' class="test"><span>ＦＵＬＬ
         ｶｸ</span></div>
-<div id='test4' class="test"><span>ＦＵＬＬ
+<div id='test4' class="test"><span>ＦＵＬＬ   
      ｶｸ</span></div>
 <div id='test5' class="test"><span>ＦＵＬＬ
 
 
 ｶｸ</span></div>
-<div id='test6' class="test"><span>ＦＵＬＬ
-
-
+<div id='test6' class="test"><span>ＦＵＬＬ  
+   
+   
    ｶｸ</span></div>
 <div id="ref" class="ref"><span>ＦＵＬＬｶｸ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-010.html
+++ b/css-text-3/white-space/seg-break-transformation-010.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>한글
 쓰기</span></div>
-<div id='test2' class="test"><span>한글
+<div id='test2' class="test"><span>한글   
 쓰기</span></div>
 <div id='test3' class="test"><span>한글
         쓰기</span></div>
-<div id='test4' class="test"><span>한글
+<div id='test4' class="test"><span>한글   
      쓰기</span></div>
 <div id='test5' class="test"><span>한글
 
 
 쓰기</span></div>
-<div id='test6' class="test"><span>한글
-
-
+<div id='test6' class="test"><span>한글  
+   
+   
    쓰기</span></div>
 <div id="ref" class="ref"><span>한글 쓰기</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-011.html
+++ b/css-text-3/white-space/seg-break-transformation-011.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>하ᄂ
 그ᄅ</span></div>
-<div id='test2' class="test"><span>하ᄂ
+<div id='test2' class="test"><span>하ᄂ   
 그ᄅ</span></div>
 <div id='test3' class="test"><span>하ᄂ
         그ᄅ</span></div>
-<div id='test4' class="test"><span>하ᄂ
+<div id='test4' class="test"><span>하ᄂ   
      그ᄅ</span></div>
 <div id='test5' class="test"><span>하ᄂ
 
 
 그ᄅ</span></div>
-<div id='test6' class="test"><span>하ᄂ
-
-
+<div id='test6' class="test"><span>하ᄂ  
+   
+   
    그ᄅ</span></div>
 <div id="ref" class="ref"><span>하ᄂ 그ᄅ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-012.html
+++ b/css-text-3/white-space/seg-break-transformation-012.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ﾾￂﾤ
 ﾡￚﾩ</span></div>
-<div id='test2' class="test"><span>ﾾￂﾤ
+<div id='test2' class="test"><span>ﾾￂﾤ   
 ﾡￚﾩ</span></div>
 <div id='test3' class="test"><span>ﾾￂﾤ
         ﾡￚﾩ</span></div>
-<div id='test4' class="test"><span>ﾾￂﾤ
+<div id='test4' class="test"><span>ﾾￂﾤ   
      ﾡￚﾩ</span></div>
 <div id='test5' class="test"><span>ﾾￂﾤ
 
 
 ﾡￚﾩ</span></div>
-<div id='test6' class="test"><span>ﾾￂﾤ
-
-
+<div id='test6' class="test"><span>ﾾￂﾤ  
+   
+   
    ﾡￚﾩ</span></div>
 <div id="ref" class="ref"><span>ﾾￂﾤ ﾡￚﾩ</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-014.html
+++ b/css-text-3/white-space/seg-break-transformation-014.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ภาษา
 ไทย</span></div>
-<div id='test2' class="test"><span>ภาษา
+<div id='test2' class="test"><span>ภาษา   
 ไทย</span></div>
 <div id='test3' class="test"><span>ภาษา
         ไทย</span></div>
-<div id='test4' class="test"><span>ภาษา
+<div id='test4' class="test"><span>ภาษา   
      ไทย</span></div>
 <div id='test5' class="test"><span>ภาษา
 
 
 ไทย</span></div>
-<div id='test6' class="test"><span>ภาษา
-
-
+<div id='test6' class="test"><span>ภาษา  
+   
+   
    ไทย</span></div>
 <div id="ref" class="ref"><span>ภาษา ไทย</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-015.html
+++ b/css-text-3/white-space/seg-break-transformation-015.html
@@ -18,37 +18,37 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ภาษา
 latin</span></div>
-<div id='test2' class="test"><span>ภาษา
+<div id='test2' class="test"><span>ภาษา   
 latin</span></div>
 <div id='test3' class="test"><span>ภาษา
         latin</span></div>
-<div id='test4' class="test"><span>ภาษา
+<div id='test4' class="test"><span>ภาษา   
      latin</span></div>
 <div id='test5' class="test"><span>ภาษา
 
 
 latin</span></div>
-<div id='test6' class="test"><span>ภาษา
-
-
+<div id='test6' class="test"><span>ภาษา  
+   
+   
    latin</span></div>
 <div id="ref1" class="ref"><span>ภาษา latin</span></div>
 
 <div id='test7' class="test"><span>latin
 ภาษา</span></div>
-<div id='test8' class="test"><span>latin
+<div id='test8' class="test"><span>latin   
 ภาษา</span></div>
 <div id='test9' class="test"><span>latin
         ภาษา</span></div>
-<div id='test10' class="test"><span>latin
+<div id='test10' class="test"><span>latin   
      ภาษา</span></div>
 <div id='test11' class="test"><span>latin
 
 
 ภาษา</span></div>
-<div id='test12' class="test"><span>latin
-
-
+<div id='test12' class="test"><span>latin  
+   
+   
    ภาษา</span></div>
 <div id="ref2" class="ref"><span>latin ภาษา</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-016.html
+++ b/css-text-3/white-space/seg-break-transformation-016.html
@@ -18,19 +18,19 @@
 <div id='log'></div>
 <div id='test1' class="test"><span>ภาษา&#x200B;
 ไทย</span></div>
-<div id='test2' class="test"><span>ภาษา&#x200B;
+<div id='test2' class="test"><span>ภาษา&#x200B;   
 ไทย</span></div>
 <div id='test3' class="test"><span>ภาษา&#x200B;
         ไทย</span></div>
-<div id='test4' class="test"><span>ภาษา&#x200B;
+<div id='test4' class="test"><span>ภาษา&#x200B;   
      ไทย</span></div>
 <div id='test5' class="test"><span>ภาษา&#x200B;
 
 
 ไทย</span></div>
-<div id='test6' class="test"><span>ภาษา&#x200B;
-
-
+<div id='test6' class="test"><span>ภาษา&#x200B;  
+   
+   
    ไทย</span></div>
 <div id="ref" class="ref"><span>ภาษาไทย</span></div>
 <script>

--- a/css-text-3/white-space/seg-break-transformation-017.html
+++ b/css-text-3/white-space/seg-break-transformation-017.html
@@ -19,17 +19,17 @@
 &#x200B;ไทย</span></div>
 <div id='test2' class="test"><span>ภาษา
    &#x200B;ไทย</span></div>
-<div id='test3' class="test"><span>ภาษา
+<div id='test3' class="test"><span>ภาษา        
 &#x200B;ไทย</span></div>
-<div id='test4' class="test"><span>ภาษา
+<div id='test4' class="test"><span>ภาษา   
      &#x200B;ไทย</span></div>
 <div id='test5' class="test"><span>ภาษา
 
 
 &#x200B;ไทย</span></div>
-<div id='test6' class="test"><span>ภาษา
-
-
+<div id='test6' class="test"><span>ภาษา  
+   
+   
    &#x200B;ไทย</span></div>
 <div id="ref" class="ref"><span>ภาษาไทย</span></div>
 <script>

--- a/css-text-3/white-space/white-space-collapse-002.html
+++ b/css-text-3/white-space/white-space-collapse-002.html
@@ -18,13 +18,13 @@
 <div id='testRLO1' class="test"><span>RLO&#x202E;
 level&#x202C;here</span></div>
 <div id="refRLO1" class="ref"><span>RLOlevel here</span></div>
-<div id='testRLO2' class="test"><span>RLO  &#x202E;
+<div id='testRLO2' class="test"><span>RLO  &#x202E; 
 level&#x202C;</span></div>
 <div id="refRLO2" class="ref"><span>RLO level</span></div>
 <div id='testRLO3' class="test"><span>RLO
    &#x202E;     level&#x202C;</span></div>
 <div id="refRLO3" class="ref"><span>RLO level</span></div>
-<div id='testRLO4' class="test"><span>RLO &#x202E;
+<div id='testRLO4' class="test"><span>RLO &#x202E;  
      level&#x202C;</span></div>
 <div id="refRLO4" class="ref"><span>RLO level</span></div>
 <div id='testRLO5' class="test"><span>RLO
@@ -36,13 +36,13 @@ level&#x202C;</span></div>
 <div id='testRLE1' class="test"><span>RLE&#x202B;
 level&#x202C;here</span></div>
 <div id="refRLE1" class="ref"><span>RLElevel here</span></div>
-<div id='testRLE2' class="test"><span>RLE  &#x202B;
+<div id='testRLE2' class="test"><span>RLE  &#x202B; 
 level&#x202C;</span></div>
 <div id="refRLE2" class="ref"><span>RLE level</span></div>
 <div id='testRLE3' class="test"><span>RLE
    &#x202B;     level&#x202C;</span></div>
 <div id="refRLE3" class="ref"><span>RLE level</span></div>
-<div id='testRLE4' class="test"><span>RLE &#x202B;
+<div id='testRLE4' class="test"><span>RLE &#x202B;  
      level&#x202C;</span></div>
 <div id="refRLE4" class="ref"><span>RLE level</span></div>
 <div id='testRLE5' class="test"><span>RLE
@@ -54,13 +54,13 @@ level&#x202C;</span></div>
 <div id='testRLI1' class="test"><span>RLI&#x2067;
 level&#x2069;here</span></div>
 <div id="refRLI1" class="ref"><span>RLIlevel here</span></div>
-<div id='testRLI2' class="test"><span>RLI  &#x2067;
+<div id='testRLI2' class="test"><span>RLI  &#x2067; 
 level&#x2069;</span></div>
 <div id="refRLI2" class="ref"><span>RLI level</span></div>
 <div id='testRLI3' class="test"><span>RLI
    &#x2067;     level&#x2069;</span></div>
 <div id="refRLI3" class="ref"><span>RLI level</span></div>
-<div id='testRLI4' class="test"><span>RLI &#x2067;
+<div id='testRLI4' class="test"><span>RLI &#x2067;  
      level&#x2069;</span></div>
 <div id="refRLI4" class="ref"><span>RLI level</span></div>
 <div id='testRLI5' class="test"><span>RLI
@@ -72,13 +72,13 @@ level&#x2069;</span></div>
 <div id='testRLM1' class="test"><span>RLM&#x200F;
 mark</span></div>
 <div id="refRLM1" class="ref"><span>RLM mark</span></div>
-<div id='testRLM2' class="test"><span>RLM  &#x200F;
+<div id='testRLM2' class="test"><span>RLM  &#x200F; 
 mark</span></div>
 <div id="refRLM2" class="ref"><span>RLM mark</span></div>
 <div id='testRLM3' class="test"><span>RLM
    &#x200F;     mark</span></div>
 <div id="refRLM3" class="ref"><span>RLM mark</span></div>
-<div id='testRLM4' class="test"><span>RLM &#x200F;
+<div id='testRLM4' class="test"><span>RLM &#x200F;  
      mark</span></div>
 <div id="refRLM4" class="ref"><span>RLM mark</span></div>
 <div id='testRLM5' class="test"><span>RLM


### PR DESCRIPTION
I believe [the recent "Remove trailing whitespace" commit](https://github.com/w3c/csswg-test/commit/55a44121247a4c94e9af8e08640617312cce625d) broke tests for that white space.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/979)
<!-- Reviewable:end -->
