### PR TITLE
[css-flexbox] Give the container an explicit height

### DIFF
--- a/css-flexbox-1/ttwf-reftest-flex-wrap-reverse.html
+++ b/css-flexbox-1/ttwf-reftest-flex-wrap-reverse.html
@@ -17,6 +17,7 @@
 	margin: 1em 0;
 	border: 1px solid black;
 	width: 20em;
+	height: 6.5em;
         }
 	span {
 	display: inline-block;

--- a/css-flexbox-1/ttwf-reftest-flex-wrap.html
+++ b/css-flexbox-1/ttwf-reftest-flex-wrap.html
@@ -17,6 +17,7 @@
 	margin: 1em 0;
 	border: 1px solid black;
 	width: 20em;
+	height: 6.5em;
         }
 	span {
 	display: inline-block;


### PR DESCRIPTION
For some reason, these tests passed on Linux for me but not on Windows.
At any rate, an explicit height is the right solution.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/984)
<!-- Reviewable:end -->
