### PR TITLE
Fix css21/pagination/widows-004a

### DIFF
--- a/css21/pagination/widows-004a.xht
+++ b/css21/pagination/widows-004a.xht
@@ -39,16 +39,16 @@
 </head>
 <body>
 	<div class="spacer">This test requires 2 pages. The blue text must
-		denote accurate page numbers. Lines A-E must appear on this page;
-		lines F-G must appear on the next page.</div>
+		denote accurate page numbers. Lines A-B must appear on this page;
+		lines C-G must appear on the next page.</div>
 
 	<div class="spacer backup"></div>
 	<div class="test">
 		Page&nbsp;1&nbsp;Line&nbsp;A
 		Page&nbsp;1&nbsp;Line&nbsp;B
-		Page&nbsp;1&nbsp;Line&nbsp;C
-		Page&nbsp;1&nbsp;Line&nbsp;D
-		Page&nbsp;1&nbsp;Line&nbsp;E
+		Page&nbsp;2&nbsp;Line&nbsp;C
+		Page&nbsp;2&nbsp;Line&nbsp;D
+		Page&nbsp;2&nbsp;Line&nbsp;E
 		Page&nbsp;2&nbsp;Line&nbsp;F
 		Page&nbsp;2&nbsp;Line&nbsp;G
 	</div>


### PR DESCRIPTION
Texts in the test seem to be incorrect.
Since the used value of widows is 5, the last 5 lines should go to the second page.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1006)

<!-- Reviewable:end -->
