### PR TITLE
[css-grid] Add test for grid item sizing within its grid area

### DIFF
--- a/css-grid-1/grid-items/grid-item-containing-block-001.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>CSS Grid Layout Test: Grid item sizing</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
+        <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+        <style type="text/css">
+            #grid {
+                display: grid;
+                width: 200px;
+                height: 200px;
+                grid-template-rows: 100px 100px;
+                grid-template-columns: 100px 100px;
+            }
+
+            #test-overlapped-red {
+                background-color: red;
+                width: 100%;
+                height: 100%;
+                grid-row: 1;
+                grid-column: 1;
+            }
+
+            #test-overlapping-green {
+                background-color: green;
+                width: 100px;
+                height: 100px;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+        <div id="grid">
+            <div id="test-overlapped-red">
+                <div id="test-overlapping-green"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-items/grid-item-containing-block-001.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.html
@@ -1,40 +1,37 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>CSS Grid Layout Test: Grid item sizing</title>
-        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
-        <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
-        <style type="text/css">
-            #grid {
-                display: grid;
-                width: 200px;
-                height: 200px;
-                grid-template-rows: 100px;
-                grid-template-columns: 100px;
-            }
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid item sizing</title>
+<link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
+<meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<style>
+    #grid {
+        display: grid;
+        width: 200px;
+        height: 200px;
+        grid-template-rows: 100px;
+        grid-template-columns: 100px;
+    }
 
-            #test-overlapped-red {
-                background-color: red;
-                width: 100%;
-                height: 100%;
-            }
+    #test-overlapped-red {
+        background-color: red;
+        width: 100%;
+        height: 100%;
+    }
 
-            #test-overlapping-green {
-                background-color: green;
-                width: 100px;
-                height: 100px;
-            }
-        </style>
-    </head>
-    <body>
-        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    #test-overlapping-green {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-        <div id="grid">
-            <div id="test-overlapped-red">
-                <div id="test-overlapping-green"></div>
-            </div>
+    <div id="grid">
+        <div id="test-overlapped-red">
+            <div id="test-overlapping-green"></div>
         </div>
-    </body>
-</html>
+    </div>
+</body>

--- a/css-grid-1/grid-items/grid-item-containing-block-001.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.html
@@ -11,16 +11,14 @@
                 display: grid;
                 width: 200px;
                 height: 200px;
-                grid-template-rows: 100px 100px;
-                grid-template-columns: 100px 100px;
+                grid-template-rows: 100px;
+                grid-template-columns: 100px;
             }
 
             #test-overlapped-red {
                 background-color: red;
                 width: 100%;
                 height: 100%;
-                grid-row: 1;
-                grid-column: 1;
             }
 
             #test-overlapping-green {

--- a/css-grid-1/grid-items/grid-item-containing-block-001.xht
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Grid Layout Test: A grid item is sized within the containing block defined by its grid area</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com" />
+        <link rel="help" href="https://www.w3.org/TR/css-grid-1/#grid-items" title="4. A grid item is sized within the containing block defined by its grid area" />
+        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <style type="text/css"><![CDATA[
+            #grid {
+                display: grid;
+                width: 200px;
+                height: 200px;
+                grid-template-rows: 100px 100px;
+                grid-template-columns: 100px 100px;
+            }
+
+            #test-overlapped-red {
+                background-color: red;
+                width: 100%;
+                height: 100%;
+                grid-row: 1;
+                grid-column: 1;
+            }
+
+            #test-overlapping-green {
+                background-color: green;
+                display: block;
+                width: 100px;
+                height: 100px;
+                grid-row: 1;
+                grid-column: 1;
+            }
+        ]]></style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+        <div id="grid">
+            <div id="test-overlapped-red">
+                <div id="test-overlapping-green"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/css-grid-1/grid-items/grid-item-containing-block-001.xht
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: A grid item is sized within the containing block defined by its grid area</title>
         <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com" />
-        <link rel="help" href="https://www.w3.org/TR/css-grid-1/#grid-items" title="4. A grid item is sized within the containing block defined by its grid area" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. A grid item is sized within the containing block defined by its grid area" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #grid {


### PR DESCRIPTION
According to https://www.w3.org/TR/css-grid-1/#grid-items
> A grid item is sized within the containing block defined by its grid area similarly to an equivalent block-level box in an equivalently-sized containing block, except that auto margins and the box alignment properties have special effects.

I think it's worth testing it regardless of `fr` unit, so it would be easier to isolate an issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1012)
<!-- Reviewable:end -->
