### PR TITLE
Make the travis builder get the right revision of the hg submodules

### DIFF
--- a/.hgsubstate
+++ b/.hgsubstate
@@ -1,2 +1,2 @@
-fd49c6c0699704308454b71cc425ab2da74a2c9d tools/apiclient
-0b71cc5e3fb6f6f243d462652a29d7f5ec195f67 tools/w3ctestlib
+38b262e4e153a3ced2d4ab283b91ddcd9f779c63 tools/apiclient
+40b0e7ed3980bef8877429bfbfd01212294a9613 tools/w3ctestlib


### PR DESCRIPTION
This is soon to be important as I do major rewrites of them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1017)
<!-- Reviewable:end -->
