### PR TITLE
[css-grid] Add more tests for grid item containing block

### DIFF
--- a/css-grid-1/grid-items/grid-item-containing-block-002.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-002.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid item sizing</title>
+<link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
+<meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<style>
+    #grid {
+        display: grid;
+        width: 200px;
+        height: 200px;
+        grid-template-rows: 50%;
+        grid-template-columns: 50%;
+    }
+
+    #test-overlapped-red {
+        background-color: red;
+        width: 100%;
+        height: 100%;
+    }
+
+    #test-overlapping-green {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+    <div id="grid">
+        <div id="test-overlapped-red">
+            <div id="test-overlapping-green"></div>
+        </div>
+    </div>
+</body>

--- a/css-grid-1/grid-items/grid-item-containing-block-003.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid item sizing</title>
+<link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
+<meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<style>
+    #grid {
+        display: grid;
+        width: 200px;
+        height: 200px;
+        grid-template-rows: 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
+    }
+
+    #test-overlapped-red {
+        background-color: red;
+        width: 100%;
+        height: 100%;
+    }
+
+    #test-overlapping-green {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+    <div id="grid">
+        <div id="test-overlapped-red">
+            <div id="test-overlapping-green"></div>
+        </div>
+    </div>
+</body>

--- a/css-grid-1/grid-items/grid-item-containing-block-004.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-004.html
@@ -15,16 +15,23 @@
         grid-template-columns: 1fr 1fr;
     }
 
-    #test-item {
-        background-color: green;
+    #test-item-overlapped-red {
+        background-color: red;
         width: 100%;
         height: 100%;
+    }
+    #reference-overlapping-green{
+        background-color: green;
+        width: 100px;
+        height: 100px;
     }
 </style>
 <body>
     <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
     <div id="grid">
-        <div id="test-item">
+        <div id="test-item-overlapped-red">
+            <div id="reference-overlapping-green">
+            </div>
         </div>
     </div>
 </body>

--- a/css-grid-1/grid-items/grid-item-containing-block-004.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-004.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>CSS Grid Layout Test: Grid item sizing</title>
+<title>CSS Grid Layout Test: Grid item sizing in a positioned grid container</title>
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
 <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
@@ -9,24 +9,20 @@
     #grid {
         display: grid;
         position: absolute;
-        height: 100px;
-        width: 100px;
-        background-color: red;
-        grid-template-columns: 1fr;
-        grid-template-rows: 1fr;
+        height: 200px;
+        width: 200px;
+        grid-template-rows: 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
     }
 
-    #test-item{
+    #test-item {
         background-color: green;
         width: 100%;
         height: 100%;
     }
-
 </style>
-
 <body>
-    <p>Test passes if there is a filled green square and
-        <strong>no red</strong>.</p>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
     <div id="grid">
         <div id="test-item">
         </div>

--- a/css-grid-1/grid-items/grid-item-containing-block-004.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-004.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid item sizing</title>
+<link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
+<meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<style>
+    #grid {
+        display: grid;
+        position: absolute;
+        height: 100px;
+        width: 100px;
+        background-color: red;
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr;
+    }
+
+    #test-item{
+        background-color: green;
+        width: 100%;
+        height: 100%;
+    }
+
+</style>
+
+<body>
+    <p>Test passes if there is a filled green square and
+        <strong>no red</strong>.</p>
+    <div id="grid">
+        <div id="test-item">
+        </div>
+    </div>
+</body>

--- a/css-grid-1/grid-items/grid-item-containing-block-004.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-004.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Grid item sizing in a positioned grid container</title>
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
-<meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
+<meta name="assert" content="A grid item is sized within the containing block defined by its grid area that intersects flexible tracks">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <style>
     #grid {


### PR DESCRIPTION
More tests for grid item sizing started at https://github.com/w3c/csswg-test/pull/1012
 - track sizes in `%`
 - track sizes in `fr`
 - track sizes in `fr`, within `absolute` positioned grid 

@mrego, I'm not sure whether last one fits here, maybe it should go to tests for flex size calculation, or even for more complex, non-direct-spec tests folder?
I thought, it would be nice to have it, as current Chrome stable failed on it (IE, Firefox, and Canary passes it)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1019)
<!-- Reviewable:end -->
