### PR TITLE
[css-sizing-3] Add tests for percentage resolution

### DIFF
--- a/css-sizing-3/percentage-resolution-001-ref.html
+++ b/css-sizing-3/percentage-resolution-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Sizing: Test that percentages don't resolve against min-content</title>
+<link rel="author" title="Google Inc." href="https://www.google.com/" />
+
+<style>
+.inner {
+  background-color: green;
+}
+</style>
+
+<body>
+  <div class="outer">
+    <div class="inner">This should be a single-line green background with no red visible.</div>
+  </div>
+</body>

--- a/css-sizing-3/percentage-resolution-001.html
+++ b/css-sizing-3/percentage-resolution-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Sizing: Test that percentages don't resolve against min-content</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#percentage-sizing" />
+<link rel="author" title="Google Inc." href="https://www.google.com/" />
+<link rel="match" href="percentage-resolution-001-ref.html" />
+
+<style>
+.outer {
+  min-height: min-content;
+  max-height: min-content;
+  height: 500px;
+  background-color: red;
+}
+
+.inner {
+  height: 50%;
+  background-color: green;
+}
+</style>
+
+<body>
+  <div class="outer">
+    <div class="inner">This should be a single-line green background with no red visible.</div>
+  </div>
+</body>


### PR DESCRIPTION
This just tests that percentages don't resolve against min-content,
which should be indefinite.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1021)

<!-- Reviewable:end -->
