### PR TITLE
[cssom-view-1] Fix outdated/broken spec anchors

### DIFF
--- a/cssom-view-1/elementFromPosition.html
+++ b/cssom-view-1/elementFromPosition.html
@@ -4,7 +4,6 @@
     <title>CSS Test: CSSOM View elementFromPoint</title>
     <meta charset="UTF-8">
     <link rel="author" title="Chris" href="mailto:pwx.frontend@gmail.com" />
-    <link rel="help" href="https://www.w3.org/TR/cssom-view/#extensions-to-the-document-interface" />
     <link rel="help" href="https://www.w3.org/TR/cssom-view/#dom-document-elementfrompoint" />
     <meta name="flags" content="dom" />
     <script src="/resources/testharness.js" type="text/javascript"></script>

--- a/cssom-view-1/elementFromPosition.html
+++ b/cssom-view-1/elementFromPosition.html
@@ -4,8 +4,8 @@
     <title>CSS Test: CSSOM View elementFromPoint</title>
     <meta charset="UTF-8">
     <link rel="author" title="Chris" href="mailto:pwx.frontend@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/cssom-view/#extensions-to-the-document-interface" />
-    <link rel="help" href="http://www.w3.org/TR/cssom-view/#widl-Document-elementFromPoint-Element-float-x-float-y" />
+    <link rel="help" href="https://www.w3.org/TR/cssom-view/#extensions-to-the-document-interface" />
+    <link rel="help" href="https://www.w3.org/TR/cssom-view/#dom-document-elementfrompoint" />
     <meta name="flags" content="dom" />
     <script src="/resources/testharness.js" type="text/javascript"></script>
     <script src="/resources/testharnessreport.js" type="text/javascript"></script>

--- a/cssom-view-1/ttwf-js-cssomview-getclientrects-length.html
+++ b/cssom-view-1/ttwf-js-cssomview-getclientrects-length.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSSOM View API Test: the length of getClientRects</title>
     <link rel="author" title="simplezeroec" href="mailto:zhaolp0419@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/cssom-view/#the-getclientrects-and-getboundingclientrect-methods">
+    <link rel="help" href="https://www.w3.org/TR/cssom-view/#dom-element-getclientrects">
     <meta name="flags" content="dom">
     <meta name="assert" content="getClientRects will return rects of the correct number">
     <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
```
Test links to unknown specification anchor: http://www.w3.org/TR/cssom-view/#widl-Document-elementFromPoint-Element-float-x-float-y
  in: cssom-view-1/elementFromPosition.html
Test links to unknown specification anchor: http://www.w3.org/TR/cssom-view/#the-getclientrects-and-getboundingclientrect-methods
  in: cssom-view-1/ttwf-js-cssomview-getclientrects-length.html
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1026)
<!-- Reviewable:end -->
