### PR TITLE
Travis CI: Don't print huge set of filepaths

### DIFF
--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -124,10 +124,10 @@ def copy_files():
 def update_git(old_files, new_files):
     git = vcs.bind_to_repo(vcs.git, built_dir)
 
-    for item in old_files - new_files:
+    for item in sorted(old_files - new_files):
         git("rm", item)
 
-    for item in new_files - old_files:
+    for item in sorted(new_files - old_files):
         git("add", item)
 
     git("add", "-u")

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -124,7 +124,6 @@ def copy_files():
 def update_git(old_files, new_files):
     git = vcs.bind_to_repo(vcs.git, built_dir)
 
-    print old_files - new_files
     for item in old_files - new_files:
         git("rm", item)
 

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -124,6 +124,9 @@ def copy_files():
 def update_git(old_files, new_files):
     git = vcs.bind_to_repo(vcs.git, built_dir)
 
+    print "RM", sorted(old_files - new_files)[:10]
+    print "ADD", sorted(new_files - old_files)[:10]
+
     for item in sorted(old_files - new_files):
         git("rm", item)
 

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -124,14 +124,8 @@ def copy_files():
 def update_git(old_files, new_files):
     git = vcs.bind_to_repo(vcs.git, built_dir)
 
-    print "RM", sorted(old_files - new_files)[:10]
-    print "ADD", sorted(new_files - old_files)[:10]
-
-    for item in sorted(old_files - new_files):
-        git("rm", item)
-
-    for item in sorted(new_files - old_files):
-        git("add", item)
+    git("rm", *sorted(old_files - new_files))
+    git("add", *sorted(new_files - old_files))
 
     git("add", "-u")
 


### PR DESCRIPTION
The size of the output seems to be causing the Travis CI build to fail.
See e.g. https://travis-ci.org/w3c/csswg-test/builds/106323094

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1029)
<!-- Reviewable:end -->
