### PR TITLE
[css-cascade] Add simple test for 'revert' keyword value

### DIFF
--- a/css-cascade-4/reference/ref-filled-green-100px-square.xht
+++ b/css-cascade-4/reference/ref-filled-green-100px-square.xht
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+  <div></div>
+
+ </body>
+</html>

--- a/css-cascade-4/revert-val-001.html
+++ b/css-cascade-4/revert-val-001.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: 'revert' keyword for 'display' property of div element</title>
+  <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+  <link rel="help" href="https://www.w3.org/TR/css-cascade-4/#default">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+  <link rel="match" href="reference/ref-filled-green-100px-square.xht">
+  <meta name="flags" content="">
+  <meta name="assert" content="On a <div>, display:revert should compute to display:block per the default styles for <div>s in the UA stylesheet.">
+  <style>
+#outer {
+  background-color: red;
+  width: 100px;
+  height: 100px;
+  overflow: hidden;
+}
+#inner {
+  color: green;
+  background-color: green;
+  display: inline;
+  display: revert;/* since #inner is a <div>, this should compute to 'block' */
+}
+  </style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div id="outer">
+    <div id="inner">
+      This<br>
+      is<br>
+      filler<br>
+      text.<br>
+      This<br>
+      is<br>
+      filler<br>
+      text.
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Currently implemented in Safari: http://caniuse.com/#feat=css-revert-value

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1067)

<!-- Reviewable:end -->
