### PR TITLE
Add shadow boundary tests for CSS Scoping Level 1

### DIFF
--- a/css-scoping-1/css-scoping-shadow-assigned-node-with-before-after.html
+++ b/css-scoping-1/css-scoping-shadow-assigned-node-with-before-after.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - ::before and ::after pseudo class' contents on a node assigned to a slot element must be rendered</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: red;
+        }
+        div {
+            display: block;
+            background: red;
+            line-height: 0px;
+            width: 100%;
+            height: 50px;
+        }
+        [slot=foo]::before,
+        [slot=foo]::after {
+            display: block;
+            content: "";
+            width: 100%;
+            height: 25px;
+        }
+        [slot=foo]::before,
+        [slot=foo]::after {
+            background: green;
+        }
+        [slot=bar]::before,
+        [slot=bar]::after {
+            background: yellow;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div slot="foo"></div>
+        <div slot="bar"></div>
+        <div slot="foo"></div>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<slot name="foo"></slot>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-assigned-node-with-rules.html
+++ b/css-scoping-1/css-scoping-shadow-assigned-node-with-rules.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - Only rules outside a shadow tree must apply to nodes assigned to a slot in the shadow tree.</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        width: 100px;
+        height: 100px;
+        overflow: hidden;
+        background: green;
+    }
+    div {
+        width: 100%;
+        height: 50%;
+    }
+    .green {
+        color: green;
+    }
+    .red {
+        color: red;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div class="red">FAIL</div>
+        <div class="green" slot="green">FAIL</div>
+        <div class="red" slot="invalid">FAIL</div>
+        <div class="green" slot="green">FAIL</div>
+    </my-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<style> div { color: yellow; } </style><slot name="green"></slot>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-host-functional-rule.html
+++ b/css-scoping-1/css-scoping-shadow-host-functional-rule.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - :host() rules must apply to the shadow host.</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#host-selector">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        host-1, host-2, host-3, host-4, host-5 {
+            display: block;
+            width: 100px;
+            height: 20px;
+            background: red;
+        }
+        host-3, host-4, host-5  {
+            background: green;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <host-1>
+        <div>FAIL1</div>
+    </host-1>
+    <host-2 id="bar" class="foo" name="baz">
+        <div>FAIL2</div>
+    </host-2>
+    <div>
+        <host-3>
+            FAIL3
+        </host-3>
+    </div>
+    <host-4>
+        <div class="child">FAIL4</div>
+    </host-4>
+    <host-5>
+        <div>FAIL5</div>
+    </host-5>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('host-1');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host(host-1) { background: green !important; } </style>';
+
+            shadowHost = document.querySelector('host-2');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host(host-2.foo#bar[name=baz]) { background: green !important; } </style>';
+
+            shadowHost = document.querySelector('host-3');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host(div host-3) { background: red !important; } </style>';
+
+            shadowHost = document.querySelector('host-4');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host(.child) { background: red !important; } </style>';
+
+            shadowHost = document.querySelector('host-5');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host(host-1) { background: red !important; } </style>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-host-rule.html
+++ b/css-scoping-1/css-scoping-shadow-host-rule.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - :host rules must apply to the shadow host.</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#host-selector">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host, my-host2, my-host3, my-host4 {
+            display: block;
+            width: 100px;
+            height: 25px;
+        }
+        my-host2 {
+            background: green;
+        }
+        my-host3 {
+            background: red;
+            color: green;
+        }
+        my-host4 {
+            background: green;
+            color: green;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div>FAIL</div>
+    </my-host>
+    <my-host2>
+        <div>FAIL</div>
+    </my-host2>
+    <my-host3>
+        <div>FAIL</div>
+    </my-host3>
+    <div class="container">
+        <my-host4>
+            <div>FAIL</div>
+        </my-host4>
+    </div>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host { color: green; background: green; } </style><div>FAIL</div>';
+
+            shadowHost = document.querySelector('my-host2');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host { color: red; background: red; } div { color: green }</style><div>FAIL</div>';
+
+            shadowHost = document.querySelector('my-host3');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> :host { background: green !important; color: green !important; } </style><div>FAIL</div>';
+
+            shadowHost = document.querySelector('my-host4');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> .container :host { background: red !important; } </style><div>FAIL</div>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-host-with-before-after.html
+++ b/css-scoping-1/css-scoping-shadow-host-with-before-after.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - ::before and ::after pseudo elements' contents on a shadow host must be rendered</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: red;
+        }
+        my-host::before {
+            display: block;
+            content: "";
+            width: 100px;
+            height: 25px;
+            background: green;
+        }
+        my-host::after {
+            display: block;
+            content: "";
+            width: 100px;
+            height: 25px;
+            background: green;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div>FAIL</div>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<div style="width: 100px; height: 50px; background: green"></div>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-invisible-slot.html
+++ b/css-scoping-1/css-scoping-shadow-invisible-slot.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - elements with a distribution list should generate boxes in the formatting tree.</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        width: 100px;
+        height: 100px;
+        overflow: hidden;
+    }
+    div {
+        width: 100%;
+        height: 50%;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div slot="green" style="background: green;"></div>
+        <div style="background: red;">FAIL</div>
+        <div slot="green" style="background: green;"></div>
+    </my-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<slot name="green" style="border: solid 50px red;"></slot>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-root-hides-children.html
+++ b/css-scoping-1/css-scoping-shadow-root-hides-children.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - a shadow tree hides non-distributed children of the host</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        width: 100px;
+        height: 100px;
+    }
+    div {
+        width: 100%; height: 100%; background: red;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div>FAIL</div>
+    </my-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<div style="width: 100px; height: 100px; background: green; color:green">FAIL</div>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-slot-display-override.html
+++ b/css-scoping-1/css-scoping-shadow-slot-display-override.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - overriding slot element's display value should generate boxes</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: red;
+        }
+        my-host > div {
+            width: 50px;
+            height: 50px;
+            background: green;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div></div>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<slot style="display:block; border: solid 25px green;"></slot>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-slot-fallback.html
+++ b/css-scoping-1/css-scoping-shadow-slot-fallback.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - slot element without distributed nodes must render its fallback content</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        background-color: red;
+        width: 100px;
+        height: 50px;
+    }
+    .red {
+        background-color: red;
+    }
+    .green {
+        background-color: green;
+    }
+    div {
+        width: 100px;
+        height: 50px;
+    }
+    slot {
+        border: solid 10px red;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <my-host></my-host>
+    <div class="red"><slot><div class="green"></div></slot></div>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<slot style="border: solid 10px red;">'
+            + '<div style="width: 100%; height: 100%; background-color: green;"></div></slot>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-slot.html
+++ b/css-scoping-1/css-scoping-shadow-slot.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - elements with a distribution list should generate boxes in the formatting tree.</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        width: 100px;
+        height: 100px;
+        overflow: hidden;
+    }
+    div {
+        width: 100%;
+        height: 50%;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div slot="green" style="background: green;"></div>
+        <div style="background: red;">FAIL</div>
+        <div slot="green" style="background: green;"></div>
+    </my-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<slot name="green"></slot>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-slotted-nested.html
+++ b/css-scoping-1/css-scoping-shadow-slotted-nested.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - ::slotted pseudo element rule must apply to an element that got slotted via another slot</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#slotted-pseudo">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        outer-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: red;
+        }
+        outer-host > * {
+            display: block;
+            width: 100px;
+            height: 25px;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <outer-host>
+        <span slot="outer">FAIL1</span>
+        <span slot="inner">FAIL2</span>
+        <span slot="both">FAIL3</span>
+    </outer-host>
+    <template id="outer-host-template">
+        <inner-host>
+            <style>
+                ::slotted([slot=outer]) { background: green; color: green; }
+                ::slotted([slot=both]) { background: green; }
+                span { display: block; width: 100px; height: 25px; }
+            </style>
+            <slot name="outer"></slot>
+            <slot name="inner"></slot>
+            <slot name="both"></slot>
+            <span slot="inner">FAIL4</span>
+        </inner-host>
+    </template>
+    <template id="inner-host-template">
+        <style>
+            ::slotted([slot=inner]) { background: green; color: green; }
+            ::slotted([slot=both]) { color: green; }
+        </style>
+        <slot></slot>
+        <slot name="inner"></slot>
+    </template>
+    <script>
+
+        try {
+            var outerHost = document.querySelector('outer-host');
+            outerShadow = outerHost.attachShadow({mode: 'closed'});
+            outerShadow.appendChild(document.getElementById('outer-host-template').content.cloneNode(true));
+
+            var innerHost = outerShadow.querySelector('inner-host');
+            innerShadow = innerHost.attachShadow({mode: 'closed'});
+            innerShadow.appendChild(document.getElementById('inner-host-template').content.cloneNode(true));
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-slotted-rule.html
+++ b/css-scoping-1/css-scoping-shadow-slotted-rule.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - :slotted pseudo element must allow selecting elements assigned to a slot element</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#slotted-pseudo">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            color: red;
+            background: green;
+        }
+        my-host > div, nested-host {
+            display: block;
+            width: 100px;
+            height: 25px;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div class="green">FAIL1</div>
+        <myelem><span>FAIL2</span></myelem>
+        <nested-host>
+            <span>FAIL3</span>
+        </nested-host>
+        <another-host>
+            <b>FAIL4</b>
+        </another-host>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<slot></slot><style> ::slotted(.green), ::slotted(myelem) { color:green; } </style>';
+
+            shadowHost = document.querySelector('nested-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> .mydiv ::slotted(*) { color:green; } </style><div class=mydiv><slot></slot></div>';
+
+            shadowHost = document.querySelector('another-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> ::slotted(*) { color:green; } </style><slot></slot>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-with-outside-rules.html
+++ b/css-scoping-1/css-scoping-shadow-with-outside-rules.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - a selector outside a shadow tree should not match nodes inside the shadow tree</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: green;
+        }
+
+        div {
+            width: 100%;
+            height: 100%;
+            background: red;
+            content: "FAIL";
+        }
+
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div>FAIL</div>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<div></div>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-with-rules-no-style-leak.html
+++ b/css-scoping-1/css-scoping-shadow-with-rules-no-style-leak.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - a style rule inside a shadow tree doesn't affect the normal dom</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+    }
+    div {
+        width: 100px;
+        height: 100px;
+        background: green;
+        color:green;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+    </my-host>
+    <div>FAIL</div>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<style> div { background: red; } </style>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/css-scoping-shadow-with-rules.html
+++ b/css-scoping-1/css-scoping-shadow-with-rules.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - a selector inside a shadow tree is matched against nodes in the shadow tree</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host {
+        display: block;
+        width: 100px;
+        height: 100px;
+    }
+    div {
+        width: 100%; height: 100%; background: red;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div>FAIL</div>
+    </my-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<div>FAIL</div><style> div {width: 100px; height: 100px; background: green; color:green; } </style>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>

--- a/css-scoping-1/reference/green-box.html
+++ b/css-scoping-1/reference/green-box.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - A green box reference</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+</head>
+<body>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>


### PR DESCRIPTION
Import tests for https://drafts.csswg.org/css-scoping/#shadow-dom
from http://trac.webkit.org/browser/trunk/LayoutTests/fast/shadow-dom

Both WebKit nightly builds and Google Chrome Canary pass all these tests
except css-scoping-shadow-slot-display-override.html which fails on Chrome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1084)
<!-- Reviewable:end -->