### PR TITLE
Add a test for inheriting style from a slot element to the slotted content

### DIFF
--- a/css-scoping-1/css-scoping-shadow-slot-style.html
+++ b/css-scoping-1/css-scoping-shadow-slot-style.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - Ensure that slot's style is inherited by slotted children</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#selectors-data-model">
+    <link rel="match" href="reference/green-box.html"/>
+</head>
+<body>
+    <style>
+    my-host, my-non-host {
+        display: block;
+        width: 100px;
+        height: 50px;
+        overflow: hidden;
+        background: red;
+        color: red;
+    }
+    div {
+        width: 100%;
+        height: 50%;
+    }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p> 
+    <my-host>
+        <div slot="green" style="background: green;">FAIL</div>
+        <div slot="green" style="background: inherit;">FAIL</div>
+    </my-host>
+    <my-non-host>
+        <slot name="green" style="color: green; background: green">
+            <div slot="green" style="background: green;">FAIL</div>
+            <div slot="green" style="background: inherit;">FAIL</div>
+        </slot>
+    </my-non-host>
+    <script>
+
+    try {
+        var shadowHost = document.querySelector('my-host');
+        shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<slot name="green" style="color: green; background: green"></slot>';
+    } catch (exception) {
+        document.body.appendChild(document.createTextNode(exception));
+    }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This test passes on WebKit nightly builds and fails on Google Chrome Canary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1087)
<!-- Reviewable:end -->
