### PR TITLE
Fix c5525-fltwidth-003

### DIFF
--- a/css21/css1/c5525-fltwidth-003-ref.xht
+++ b/css21/css1/c5525-fltwidth-003-ref.xht
@@ -8,12 +8,20 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
   <style type="text/css"><![CDATA[
+  body
+  {
+  line-height: 24px;
+  }
+  img
+  {
+  vertical-align: top;
+  }
   div > div
   {
   position: relative;
   left: 50%;
   text-indent: 15px;
-  bottom: 19px;
+  bottom: 24px;
   width: 50%;
   }
   ]]></style>

--- a/css21/css1/c5525-fltwidth-003.xht
+++ b/css21/css1/c5525-fltwidth-003.xht
@@ -9,6 +9,15 @@
   <link rel="match" href="c5525-fltwidth-003-ref.xht" />
 
   <style type="text/css"><![CDATA[
+   html {
+     image-rendering: -webkit-optimize-contrast;
+     image-rendering: pixelated;
+     image-rendering: -moz-crisp-edges;
+     image-rendering: -o-crisp-edges;
+     image-rendering: crisp-edges;
+     -ms-interpolation-mode: nearest-neighbor;
+   }
+   body { line-height: 24px; }
    .a { background: url(support/pattern-tr.png) center top no-repeat; }
    .b { background: url(support/swatch-red.png) left top no-repeat; }
    p { margin: 0; float: left; width: 50%; }


### PR DESCRIPTION
- `vertical-align: top` should be specified to the img element in the reference in the same way as in the test case.
- `line-height` should be explicitly specified since the `bottom` value specified to the `position: relative` block in the reference should be exactly the same as the line-height value.
- Avoid blur of background images on a HiDPI display by `image-rendering: crisp-edges` (and alternatives for browsers which do not support it).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1090)

<!-- Reviewable:end -->
