### PR TITLE
Pin html5lib to 0.9999999 for now.

### DIFF
--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -86,7 +86,7 @@ def setup_virtualenv():
     execfile(activate_path, dict(__file__=activate_path))
 
     subprocess.check_call(["pip", "-q", "install", "mercurial"])
-    subprocess.check_call(["pip", "-q", "install", "html5lib"])
+    subprocess.check_call(["pip", "-q", "install", "html5lib==0.9999999"])
     subprocess.check_call(["pip", "-q", "install", "lxml"])
     subprocess.check_call(["pip", "-q", "install", "Template-Python"])
 


### PR DESCRIPTION
w3ctestlib depends on private APIs that were removed in later versions.

gsnedders is working to rectify that, but right now this is the safest way
back to working travis builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1099)
<!-- Reviewable:end -->
