### PR TITLE
Fix flex-grow-006.html

### DIFF
--- a/css-flexbox-1/flex-grow-006.html
+++ b/css-flexbox-1/flex-grow-006.html
@@ -20,7 +20,7 @@
     width: 25px;
   }
   #test1 {
-    flex-grow: 0.5;
+    flex-grow: 1.5;
   }
   #test2 {
     flex-grow: 2;


### PR DESCRIPTION
The test wants to make sure that "any positive flex factor" grows the flex item to full size, but fractional flex factors < 1 do not do that. Instead, let's use 1.5 here.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1104)

<!-- Reviewable:end -->
