### PR TITLE
[css-syntax] Added test for three code points for an ident

### DIFF
--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -65,56 +65,11 @@
     <script>
         var items = document.getElementsByClassName('item');
 
-        generate_tests(assert_equals, [
-            [
-                // One
-                items[0].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[0]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Two
-                items[1].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[1]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Three
-                items[2].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[2]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Four
-                items[3].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[3]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Five
-                items[4].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[4]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Six
-                items[5].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[5]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Seven
-                items[6].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[6]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ],
-            [
-                // Eight
-                items[7].getAttribute('name') + " should be green",
-                window.getComputedStyle(items[7]).getPropertyValue('background-color'),
-                "rgb(0, 128, 0)"
-            ]
-        ]);
+        for(var i=0; i < items.length; i++) {
+            test(function() {
+                assert_equals(window.getComputedStyle(items[i]).getPropertyValue('background-color'), "rgb(0, 128, 0)");
+            }, items[i].getAttribute('name') + " should be green");
+        }        
     </script>
 </body>
 </html>

--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -6,7 +6,7 @@
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />
-<link rel="help" href="https://drafts.csswg.org/css-syntax-3/" />
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier" />
 <style>
     main div {
       background-color:red;

--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<link rel='stylesheet' href='/resources/testharness.css'>
+<link rel='stylesheet' href='../base.css' />
+
+<link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />
+<link rel="help" href="https://drafts.csswg.org/css-syntax/#would-start-an-identifier" />
+<style>
+    main div {
+      background-color:red;
+    }
+
+    #1 {
+      background-color:green;
+    }
+
+    #-2 {
+      background-color:green;
+    }
+
+    #--3 {
+      background-color:green;
+    }
+
+    #---4 {
+      background-color:green;
+    }
+
+    #a {
+      background-color:green;
+    }
+
+    #-b {
+      background-color:green;
+    }
+
+    #--c {
+      background-color:green;
+    }
+
+    #---d {
+      background-color:green;
+    }
+</style>
+<body>
+    <main>
+        <div id="1" class="item" name="one">test1</div>
+        <div id="-2" class="item" name="two">test2</div>
+        <div id="--3" class="item" name="three">test3</div>
+        <div id="---4" class="item" name="four">test4</div>
+
+        <div id="a" class="item" name="five">test A</div>
+        <div id="-b" class="item" name="six">test B</div>
+        <div id="--c" class="item" name="seven">test C</div>
+        <div id="---d" class="item" name="eight">test D</div>
+    </main>
+
+    <script>
+        var items = document.getElementsByClassName('item');
+
+        generate_tests(assert_equals, [
+            [
+                // One
+                items[0].getAttribute('name') + " should be red",
+                window.getComputedStyle(document.getElementsByClassName('item')[0]).getPropertyValue('background-color'),
+                "rgb(255, 0, 0)"
+            ],
+            [
+                // Two
+                items[1].getAttribute('name') + " should be red",
+                window.getComputedStyle(document.getElementsByClassName('item')[1]).getPropertyValue('background-color'),
+                "rgb(255, 0, 0)"
+            ],
+            [
+                // Three
+                items[2].getAttribute('name') + " should be green",
+                window.getComputedStyle(document.getElementsByClassName('item')[2]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
+            ],
+            [
+                // Four
+                items[3].getAttribute('name') + " should be red",
+                window.getComputedStyle(document.getElementsByClassName('item')[3]).getPropertyValue('background-color'),
+                "rgb(255, 0, 0)"
+            ],
+            [
+                // Five
+                items[4].getAttribute('name') + " should be green",
+                window.getComputedStyle(document.getElementsByClassName('item')[4]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
+            ],
+            [
+                // Six
+                items[5].getAttribute('name') + " should be green",
+                window.getComputedStyle(document.getElementsByClassName('item')[5]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
+            ],
+            [
+                // Seven
+                items[6].getAttribute('name') + " should be green",
+                window.getComputedStyle(document.getElementsByClassName('item')[6]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
+            ],
+            [
+                // Eight
+                items[7].getAttribute('name') + " should be red",
+                window.getComputedStyle(document.getElementsByClassName('item')[7]).getPropertyValue('background-color'),
+                "rgb(255, 0, 0)"
+            ]
+        ]);
+    </script>
+</body>
+</html>

--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -12,12 +12,17 @@
       background-color:red;
     }
 
+    div[name=one],
+    div[name=two] {
+        background: green;
+    }
+
     #1 {
-      background-color:green;
+      background-color:red;
     }
 
     #-2 {
-      background-color:green;
+      background-color:red;
     }
 
     #--3 {
@@ -63,51 +68,51 @@
         generate_tests(assert_equals, [
             [
                 // One
-                items[0].getAttribute('name') + " should be red",
-                window.getComputedStyle(document.getElementsByClassName('item')[0]).getPropertyValue('background-color'),
-                "rgb(255, 0, 0)"
+                items[0].getAttribute('name') + " should be green",
+                window.getComputedStyle(items[0]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
             ],
             [
                 // Two
-                items[1].getAttribute('name') + " should be red",
-                window.getComputedStyle(document.getElementsByClassName('item')[1]).getPropertyValue('background-color'),
-                "rgb(255, 0, 0)"
+                items[1].getAttribute('name') + " should be green",
+                window.getComputedStyle(items[1]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
             ],
             [
                 // Three
                 items[2].getAttribute('name') + " should be green",
-                window.getComputedStyle(document.getElementsByClassName('item')[2]).getPropertyValue('background-color'),
+                window.getComputedStyle(items[2]).getPropertyValue('background-color'),
                 "rgb(0, 128, 0)"
             ],
             [
                 // Four
-                items[3].getAttribute('name') + " should be red",
-                window.getComputedStyle(document.getElementsByClassName('item')[3]).getPropertyValue('background-color'),
-                "rgb(255, 0, 0)"
+                items[3].getAttribute('name') + " should be green",
+                window.getComputedStyle(items[3]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
             ],
             [
                 // Five
                 items[4].getAttribute('name') + " should be green",
-                window.getComputedStyle(document.getElementsByClassName('item')[4]).getPropertyValue('background-color'),
+                window.getComputedStyle(items[4]).getPropertyValue('background-color'),
                 "rgb(0, 128, 0)"
             ],
             [
                 // Six
                 items[5].getAttribute('name') + " should be green",
-                window.getComputedStyle(document.getElementsByClassName('item')[5]).getPropertyValue('background-color'),
+                window.getComputedStyle(items[5]).getPropertyValue('background-color'),
                 "rgb(0, 128, 0)"
             ],
             [
                 // Seven
                 items[6].getAttribute('name') + " should be green",
-                window.getComputedStyle(document.getElementsByClassName('item')[6]).getPropertyValue('background-color'),
+                window.getComputedStyle(items[6]).getPropertyValue('background-color'),
                 "rgb(0, 128, 0)"
             ],
             [
                 // Eight
-                items[7].getAttribute('name') + " should be red",
-                window.getComputedStyle(document.getElementsByClassName('item')[7]).getPropertyValue('background-color'),
-                "rgb(255, 0, 0)"
+                items[7].getAttribute('name') + " should be green",
+                window.getComputedStyle(items[7]).getPropertyValue('background-color'),
+                "rgb(0, 128, 0)"
             ]
         ]);
     </script>

--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -3,7 +3,6 @@
 <script src='/resources/testharnessreport.js'></script>
 <title>Testing valid ident based on first three code points</title>
 <link rel='stylesheet' href='/resources/testharness.css'>
-<link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />
 <link rel="help" href="https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier" />

--- a/css-syntax-3/ident-three-code-points.html
+++ b/css-syntax-3/ident-three-code-points.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<title>Testing valid ident based on first three code points</title>
 <link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />
-<link rel="help" href="https://drafts.csswg.org/css-syntax/#would-start-an-identifier" />
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/" />
 <style>
     main div {
       background-color:red;


### PR DESCRIPTION
Based on a discussion with @tabatkins I have created a new testcase for determining if an ID is a valid id after 3 codepoints. This will replace (although I didn't delete it) ident-20.xht in CSS 2. I have placed this within the L3 folder as we have done in other modules even though there are only tests for charset currently within the module. Based on the spec, I believe this is correct but Firefox/Chrome currently allow `---` to be a valid ident even though the current spec text only allows two of them (assuming I'm reading it correctly).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1134)
<!-- Reviewable:end -->
