### PR TITLE
Glyph metric units

### DIFF
--- a/css-values-3/ch-unit-001.html
+++ b/css-values-3/ch-unit-001.html
@@ -8,30 +8,30 @@
 <meta name="assert" content="The ch unit is equal to the used advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	top: 0; bottom: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    top: 0; bottom: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 10ch;
-	width: 5ch;
-	float: left;
+    background: red;
+    color: red;
+    position: relative;
+    height: 10ch;
+    width: 5ch;
+    float: left;
 }
 
 div + div {
-	width: auto;
+    width: auto;
 }
 
 div + div span {
-	width: 5ch;
+    width: 5ch;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>00000</span></div>
-  <div><span></span>00000</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>00000</span></div>
+    <div><span></span>00000</div>
 </body>

--- a/css-values-3/ch-unit-002.html
+++ b/css-values-3/ch-unit-002.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: the ch unit in vertical orientation</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-3/#font-relative-lengths">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">
+<link rel="match" href="reference/ch-unit-002-ref.html">
+<meta name="assert" content="In vertical upright, the ch unit is equal to the used vertical advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ch;
+	width: 10ch;
+	writing-mode: vertical-rl;
+	text-orientation: upright;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>00000</span></div>
+  <div><span></span>00000</div>
+</body>

--- a/css-values-3/ch-unit-002.html
+++ b/css-values-3/ch-unit-002.html
@@ -9,31 +9,31 @@
 <meta name="assert" content="In vertical upright, the ch unit is equal to the used vertical advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ch;
-	width: 10ch;
-	writing-mode: vertical-rl;
-	text-orientation: upright;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ch;
+    width: 10ch;
+    writing-mode: vertical-rl;
+    text-orientation: upright;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ch;
+    height: 5ch;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>00000</span></div>
-  <div><span></span>00000</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>00000</span></div>
+    <div><span></span>00000</div>
 </body>

--- a/css-values-3/ch-unit-003.html
+++ b/css-values-3/ch-unit-003.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: support for the ch unit</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-3/#font-relative-lengths">
+<meta name="flags" content="">
+<link rel="match" href="reference/ch-unit-001-ref.html">
+<meta name="assert" content="In vertical mixed, The ch unit is equal to the used horizontal advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ch;
+	width: 10ch;
+	writing-mode: vertical-rl;
+	text-orientation: mixed;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>00000</span></div>
+  <div><span></span>00000</div>
+</body>

--- a/css-values-3/ch-unit-003.html
+++ b/css-values-3/ch-unit-003.html
@@ -8,31 +8,31 @@
 <meta name="assert" content="In vertical mixed, The ch unit is equal to the used horizontal advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ch;
-	width: 10ch;
-	writing-mode: vertical-rl;
-	text-orientation: mixed;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ch;
+    width: 10ch;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ch;
+    height: 5ch;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>00000</span></div>
-  <div><span></span>00000</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>00000</span></div>
+    <div><span></span>00000</div>
 </body>

--- a/css-values-3/ch-unit-004.html
+++ b/css-values-3/ch-unit-004.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: support for the ch unit</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-3/#font-relative-lengths">
+<meta name="flags" content="">
+<link rel="match" href="reference/ch-unit-001-ref.html">
+<meta name="assert" content="In vertical sideways, The ch unit is equal to the used horizontal advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ch;
+	width: 10ch;
+	writing-mode: vertical-rl;
+	text-orientation: sideways;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>00000</span></div>
+  <div><span></span>00000</div>
+</body>

--- a/css-values-3/ch-unit-004.html
+++ b/css-values-3/ch-unit-004.html
@@ -8,31 +8,31 @@
 <meta name="assert" content="In vertical sideways, The ch unit is equal to the used horizontal advance measure of the 0 (ZERO, U+0030) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ch;
-	width: 10ch;
-	writing-mode: vertical-rl;
-	text-orientation: sideways;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ch;
+    width: 10ch;
+    writing-mode: vertical-rl;
+    text-orientation: sideways;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ch;
+    height: 5ch;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>00000</span></div>
-  <div><span></span>00000</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>00000</span></div>
+    <div><span></span>00000</div>
 </body>

--- a/css-values-3/reference/ch-unit-001-ref.html
+++ b/css-values-3/reference/ch-unit-001-ref.html
@@ -6,6 +6,6 @@
 svg { width: 10ch; }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
 </body>

--- a/css-values-3/reference/ch-unit-002-ref.html
+++ b/css-values-3/reference/ch-unit-002-ref.html
@@ -3,7 +3,11 @@
 <title>CSS Values and Units Test Reference File</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <style>
-svg { width: 10ch; }
+svg {
+	width: 10ch;
+	writing-mode: vertical-rl;
+	text-orientation: upright;
+}
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>

--- a/css-values-3/reference/ch-unit-002-ref.html
+++ b/css-values-3/reference/ch-unit-002-ref.html
@@ -4,12 +4,12 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <style>
 svg {
-	width: 10ch;
-	writing-mode: vertical-rl;
-	text-orientation: upright;
+    width: 10ch;
+    writing-mode: vertical-rl;
+    text-orientation: upright;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
 </body>

--- a/css-values-4/ic-unit-001.html
+++ b/css-values-4/ic-unit-001.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: support for the ic unit</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<link rel="match" href="reference/ic-unit-001-ref.html">
+<meta name="assert" content="The ic unit is equal to the used advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	top: 0; bottom: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 10ic;
+	width: 5ic;
+	float: left;
+}
+
+div + div {
+	width: auto;
+}
+
+div + div span {
+	width: 5ic;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>水水水水水</span></div>
+  <div><span></span>水水水水水</div>
+</body>

--- a/css-values-4/ic-unit-001.html
+++ b/css-values-4/ic-unit-001.html
@@ -7,30 +7,30 @@
 <meta name="assert" content="The ic unit is equal to the used advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	top: 0; bottom: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    top: 0; bottom: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 10ic;
-	width: 5ic;
-	float: left;
+    background: red;
+    color: red;
+    position: relative;
+    height: 10ic;
+    width: 5ic;
+    float: left;
 }
 
 div + div {
-	width: auto;
+    width: auto;
 }
 
 div + div span {
-	width: 5ic;
+    width: 5ic;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>水水水水水</span></div>
-  <div><span></span>水水水水水</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>水水水水水</span></div>
+    <div><span></span>水水水水水</div>
 </body>

--- a/css-values-4/ic-unit-002.html
+++ b/css-values-4/ic-unit-002.html
@@ -9,31 +9,31 @@
 <meta name="assert" content="In vertical upright, the ic unit is equal to the used vertical advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ic;
-	width: 10ic;
-	writing-mode: vertical-rl;
-	text-orientation: upright;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ic;
+    width: 10ic;
+    writing-mode: vertical-rl;
+    text-orientation: upright;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ic;
+    height: 5ic;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>水水水水水</span></div>
-  <div><span></span>水水水水水</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>水水水水水</span></div>
+    <div><span></span>水水水水水</div>
 </body>

--- a/css-values-4/ic-unit-002.html
+++ b/css-values-4/ic-unit-002.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: the ic unit in vertical orientation</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">
+<link rel="match" href="reference/ic-unit-002-ref.html">
+<meta name="assert" content="In vertical upright, the ic unit is equal to the used vertical advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ic;
+	width: 10ic;
+	writing-mode: vertical-rl;
+	text-orientation: upright;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ic;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>水水水水水</span></div>
+  <div><span></span>水水水水水</div>
+</body>

--- a/css-values-4/ic-unit-003.html
+++ b/css-values-4/ic-unit-003.html
@@ -9,31 +9,31 @@
 <meta name="assert" content="In vertical mixed, the ic unit is equal to the used vertical advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ic;
-	width: 10ic;
-	writing-mode: vertical-rl;
-	text-orientation: mixed;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ic;
+    width: 10ic;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ic;
+    height: 5ic;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>水水水水水</span></div>
-  <div><span></span>水水水水水</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>水水水水水</span></div>
+    <div><span></span>水水水水水</div>
 </body>

--- a/css-values-4/ic-unit-003.html
+++ b/css-values-4/ic-unit-003.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: the ic unit in vertical orientation</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">
+<link rel="match" href="reference/ic-unit-002-ref.html">
+<meta name="assert" content="In vertical mixed, the ic unit is equal to the used vertical advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ic;
+	width: 10ic;
+	writing-mode: vertical-rl;
+	text-orientation: mixed;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ic;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>水水水水水</span></div>
+  <div><span></span>水水水水水</div>
+</body>

--- a/css-values-4/ic-unit-004.html
+++ b/css-values-4/ic-unit-004.html
@@ -9,31 +9,31 @@
 <meta name="assert" content="In vertical sideways, the ic unit is equal to the used horizontal advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
 <style>
 span {
-	background: green;
-	color: green;
-	left: 0; right: 0;
-	position: absolute;
+    background: green;
+    color: green;
+    left: 0; right: 0;
+    position: absolute;
 }
 div {
-	background: red;
-	color: red;
-	position: relative;
-	height: 5ic;
-	width: 10ic;
-	writing-mode: vertical-rl;
-	text-orientation: sideways;
+    background: red;
+    color: red;
+    position: relative;
+    height: 5ic;
+    width: 10ic;
+    writing-mode: vertical-rl;
+    text-orientation: sideways;
 }
 
 div + div {
-	height: auto;
+    height: auto;
 }
 
 div + div span {
-	height: 5ic;
+    height: 5ic;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div><span>水水水水水</span></div>
-  <div><span></span>水水水水水</div>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <div><span>水水水水水</span></div>
+    <div><span></span>水水水水水</div>
 </body>

--- a/css-values-4/ic-unit-004.html
+++ b/css-values-4/ic-unit-004.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: the ic unit in vertical orientation</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">
+<link rel="match" href="reference/ic-unit-001-ref.html">
+<meta name="assert" content="In vertical sideways, the ic unit is equal to the used horizontal advance measure of the 水 (CJK water ideograph, U+6C34) glyph found in the font used to render it.">
+<style>
+span {
+	background: green;
+	color: green;
+	left: 0; right: 0;
+	position: absolute;
+}
+div {
+	background: red;
+	color: red;
+	position: relative;
+	height: 5ic;
+	width: 10ic;
+	writing-mode: vertical-rl;
+	text-orientation: sideways;
+}
+
+div + div {
+	height: auto;
+}
+
+div + div span {
+	height: 5ic;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div><span>水水水水水</span></div>
+  <div><span></span>水水水水水</div>
+</body>

--- a/css-values-4/reference/ic-unit-001-ref.html
+++ b/css-values-4/reference/ic-unit-001-ref.html
@@ -6,6 +6,6 @@
 svg { width: 10ic; }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
 </body>

--- a/css-values-4/reference/ic-unit-001-ref.html
+++ b/css-values-4/reference/ic-unit-001-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test Reference File</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+svg { width: 10ic; }
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+</body>

--- a/css-values-4/reference/ic-unit-002-ref.html
+++ b/css-values-4/reference/ic-unit-002-ref.html
@@ -4,12 +4,12 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <style>
 svg {
-	width: 10ic;
-	writing-mode: vertical-rl;
-	text-orientation: upright;
+    width: 10ic;
+    writing-mode: vertical-rl;
+    text-orientation: upright;
 }
 </style>
 <body>
-  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+    <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+    <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
 </body>

--- a/css-values-4/reference/ic-unit-002-ref.html
+++ b/css-values-4/reference/ic-unit-002-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test Reference File</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+svg {
+	width: 10ic;
+	writing-mode: vertical-rl;
+	text-orientation: upright;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <svg viewBox="0 0 100 100"><rect x="0" y="0" width="100" height="100" fill="green"></svg>
+</body>


### PR DESCRIPTION
Adds a vertical variant of the existing test  for the `ch` unit, and both a horiztonal and a vertical equivalent for the `ic` unit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1136)

<!-- Reviewable:end -->
