### PR TITLE
[css-display-3] Make contents tests independent of text-shaping.

### DIFF
--- a/css-display-3/display-contents-before-after-002.html
+++ b/css-display-3/display-contents-before-after-002.html
@@ -15,4 +15,4 @@
     }
 </style>
 <p>You should see the word PASS below.</p>
-<div>AS</div>
+<div>A<span>S</span></div>

--- a/css-display-3/display-contents-block-001.html
+++ b/css-display-3/display-contents-block-001.html
@@ -13,6 +13,6 @@
 <p>You should see the word PASS and no red below.</p>
 <div>
     <div id="contents">
-        <div id="inner">PASS</div>
+        <div id="inner">P<span>A</span>S<span>S</span></div>
     </div>
 </div>

--- a/css-display-3/display-contents-first-line-001.html
+++ b/css-display-3/display-contents-first-line-001.html
@@ -12,5 +12,5 @@
 </style>
 <p>You should see the word PASS in green and no red below.</p>
 <div id="container">
-    <div id="contents">PASS</div>
+    <div id="contents"><span>P</span>ASS</div>
 </div>

--- a/css-display-3/display-contents-inline-001.html
+++ b/css-display-3/display-contents-inline-001.html
@@ -12,5 +12,5 @@
 </style>
 <p>You should see the word PASS and no red below.</p>
 <span>
-    P<div id="contents">AS</div>S
+    P<div id="contents">A<span>S</span></div>S
 </span>

--- a/css-display-3/display-contents-pass-green-no-red-ref.html
+++ b/css-display-3/display-contents-pass-green-no-red-ref.html
@@ -3,4 +3,4 @@
 <title>CSS Reftest Reference</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
 <p>You should see the word PASS in green and no red below.</p>
-<div style="color:green">PASS</div>
+<div style="color:green"><span>P</span>ASS</div>

--- a/css-display-3/display-contents-pass-no-red-ref.html
+++ b/css-display-3/display-contents-pass-no-red-ref.html
@@ -3,4 +3,4 @@
 <title>CSS Reftest Reference</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
 <p>You should see the word PASS and no red below.</p>
-<div>PASS</div>
+<div>P<span>A</span>S<span>S</span></div>

--- a/css-display-3/display-contents-pass-ref.html
+++ b/css-display-3/display-contents-pass-ref.html
@@ -3,4 +3,4 @@
 <title>CSS Reftest Reference</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
 <p>You should see the word PASS below.</p>
-PASS
+P<span>A</span>S<span>S</span>

--- a/css-display-3/display-contents-tr-001.html
+++ b/css-display-3/display-contents-tr-001.html
@@ -10,9 +10,9 @@
 <p>You should see the word PASS below.</p>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td>PA</td>
+        <td>P<span>A</span></td>
     </tr>
     <tr>
-        <td>SS</td>
+        <td>S<span>S</span></td>
     </tr>
 </table>


### PR DESCRIPTION
Several of the display:contents tests exercised a text shaping bug in
Blink where "PASS" would be rendered differently from
"P<span>ASS</span>". Adjust tests and references to split the text the
same way across tests and references. We are testing display:contents,
not text shaping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1143)
<!-- Reviewable:end -->
