### PR TITLE
[css-display-3] Add a explicit reference for display-contents-tr-001.html to avoid text shaping bugs in Blink.

### DIFF
--- a/css-display-3/display-contents-tr-001-ref.html
+++ b/css-display-3/display-contents-tr-001-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<p>You should see the word PASS below.</p>
+<table cellpadding="0" cellspacing="0">
+  <tr>
+    <td>P<span>A</span></td>
+    <td>S<span>S</span></td>
+  </tr>
+</table>

--- a/css-display-3/display-contents-tr-001.html
+++ b/css-display-3/display-contents-tr-001.html
@@ -3,7 +3,7 @@
 <title>CSS Display: td elements wrapped in single anonymous table-row with display:contents tr</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
-<link rel="match" href="display-contents-pass-ref.html">
+<link rel="match" href="display-contents-tr-001-ref.html">
 <style>
     tr { display: contents }
 </style>


### PR DESCRIPTION
r? @rune-opera 

(Kept you as the author, it's intentional)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1146)
<!-- Reviewable:end -->
