### PR TITLE
[css-ui] Fix mistake on caret-color-009.html test

### DIFF
--- a/css-ui-3/caret-color-009.html
+++ b/css-ui-3/caret-color-009.html
@@ -30,7 +30,7 @@ test(
 test(
   function(){
    var d2 = document.getElementById("d2");
-   assert_equals(window.getComputedStyle(d1)["caret-color"], "currentcolor");
+   assert_equals(window.getComputedStyle(d2)["caret-color"], "currentcolor");
   }, "The computed value of currentcolor should be currentcolor");
 </script>
 </body>


### PR DESCRIPTION
It was referencing twice "d1" when the second time it should use "d2".

Please @frivoal take a look. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1147)
<!-- Reviewable:end -->
