### PR TITLE
[css-ui] Use bigger font and lime color for caret-color tests

### DIFF
--- a/css-ui-3/caret-color-001.html
+++ b/css-ui-3/caret-color-001.html
@@ -8,13 +8,13 @@
 <meta name="assert" content="Test checks that caret-color can be set on a textarea">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;
     background: black; color: white; /* the color of a thin object like the caret is easier to see on a black background. */
 
-    caret-color: green;
+    caret-color: lime;
   }
 </style>
 <body>

--- a/css-ui-3/caret-color-002.html
+++ b/css-ui-3/caret-color-002.html
@@ -8,14 +8,14 @@
 <meta name="assert" content="Test checks that caret-color value does inherit">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;
     background: black; color: white; /* the color of a thin object like the caret is easier to see on a black background. */
   }
   div {
-    caret-color: green;
+    caret-color: lime;
   }
 </style>
 <body>

--- a/css-ui-3/caret-color-003.html
+++ b/css-ui-3/caret-color-003.html
@@ -8,13 +8,13 @@
 <meta name="assert" content="Test checks that caret-color: auto matches currentColor">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;
     background: black; /* the color of a thin object like the caret is easier to see on a black background. */
 
-    color: green;
+    color: lime;
     caret-color: auto; /*initial value, but to be sure in case the UA stylesheet sets something else */
   }
 </style>

--- a/css-ui-3/caret-color-004.html
+++ b/css-ui-3/caret-color-004.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="Test checks that caret-color:auto provides good contrast in black on white">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;

--- a/css-ui-3/caret-color-005.html
+++ b/css-ui-3/caret-color-005.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="Test checks that caret-color:auto provides good contrast in white on black">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;

--- a/css-ui-3/caret-color-006.html
+++ b/css-ui-3/caret-color-006.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="Test checks that caret-color:auto provides good contrast in gray on gray">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;

--- a/css-ui-3/caret-color-007.html
+++ b/css-ui-3/caret-color-007.html
@@ -9,13 +9,13 @@
 <meta name="assert" content="Test checks that caret-color:currentColor is inherited as currentColor and resolves to the value of the color property at used value time">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;
     background: black; /* the color of a thin object like the caret is easier to see on a black background. */
 
-    color: green;
+    color: lime;
   }
   div {
     caret-color: currentcolor;

--- a/css-ui-3/caret-color-008.html
+++ b/css-ui-3/caret-color-008.html
@@ -8,7 +8,7 @@
 <meta name="assert" content="Test checks that caret-color is animatable as a color">
 <style>
   textarea {
-    font-size: 2em;
+    font-size: 3em;
     font-weight: bold;
     width: 10em;
     padding: 10px;
@@ -18,7 +18,7 @@
     animation: caret-many-colors 5s linear alternate infinite;
   }
   @keyframes caret-many-colors {
-	0% { caret-color: green; }
+	0% { caret-color: lime; }
 	20% { caret-color: gray; }
 	40% { caret-color: cyan; }
 	60% { caret-color: pink; }


### PR DESCRIPTION
This makes easier to see the caret as lime is used over a black background.

I believe it's easier to see lime over black than green over black.
What do you think @frivoal ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1150)
<!-- Reviewable:end -->
