### PR TITLE
Fix cssom-cssText-serialize.html

### DIFF
--- a/cssom-1/cssom-cssText-serialize.html
+++ b/cssom-1/cssom-cssText-serialize.html
@@ -24,7 +24,7 @@
           test(function(){
 
             style.left = "10px";
-            assert_equals(style.cssText, "left: 10px");
+            assert_equals(style.cssText, "left: 10px;");
             style.right = "20px";
             assert_equals(style.cssText, "left: 10px; right: 20px;");
 


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom/#serialize-a-css-declaration there's an unconditional semicolon.

This test currently fails in both Chrome and Firefox because of the missing semicolon.

r? @zcorpan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1154)
<!-- Reviewable:end -->
