### PR TITLE
[css-display-3] Tests for display: contents.

### DIFF
--- a/css-display-3/display-contents-computed-style.html
+++ b/css-display-3/display-contents-computed-style.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
-    .contents { display: contents }
+    html, .contents { display: contents }
 
     #t2 .contents { background-color: green }
     #t2 span { background-color: inherit }
@@ -66,4 +66,8 @@
         assert_equals(computed.marginLeft, "25%");
         assert_equals(computed.paddingTop, "10%");
     }, "Resolved value should be computed value, not used value, for display:contents");
+
+    test(function(){
+        assert_equals(getComputedStyle(document.documentElement).display, "block");
+    }, "Document element can't have display: contents");
 </script>

--- a/css-display-3/display-contents-computed-style.html
+++ b/css-display-3/display-contents-computed-style.html
@@ -3,6 +3,7 @@
 <title>CSS Display: Computed style for display:contents</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#transformations">
 <link rel="help" href="https://drafts.csswg.org/cssom-1/#resolved-values">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -69,5 +70,5 @@
 
     test(function(){
         assert_equals(getComputedStyle(document.documentElement).display, "block");
-    }, "Document element can't have display: contents");
+    }, "display:contents is blockified for root elements");
 </script>

--- a/css-display-3/display-contents-dynamic-flex-001-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-001-inline.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-001-ref.html">
-<script src="./support/util.js"></script>
+<script src="support/util.js"></script>
 <style>
 .flex {
   display: flex;

--- a/css-display-3/display-contents-dynamic-flex-001-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-001-inline.html
@@ -14,9 +14,10 @@
 }
 .contents {
   display: contents;
+  border: 1px solid red;
 }
 </style>
-<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S", and no red</p>
 <div class="flex">
 P
   <div class="contents">

--- a/css-display-3/display-contents-dynamic-flex-001-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-001-inline.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display 3: Display contents reattachment works well in a flex container</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-001-ref.html">
+<script src="./support/util.js"></script>
+<style>
+.flex {
+  display: flex;
+}
+.inline {
+  display: inline;
+}
+.contents {
+  display: contents;
+}
+</style>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<div class="flex">
+P
+  <div class="contents">
+    <div>A</div>
+  </div>
+  <div class="contents">
+    <div class="inline">S<div>0</div></div>
+  </div>
+  <div class="contents">
+    S
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-001-none.html
+++ b/css-display-3/display-contents-dynamic-flex-001-none.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-001-ref.html">
-<script src="./support/util.js"></script>
+<script src="support/util.js"></script>
 <style>
 .flex {
   display: flex;

--- a/css-display-3/display-contents-dynamic-flex-001-none.html
+++ b/css-display-3/display-contents-dynamic-flex-001-none.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display 3: Display contents reattachment works well in a flex container</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-001-ref.html">
+<script src="./support/util.js"></script>
+<style>
+.flex {
+  display: flex;
+}
+.inline {
+  display: inline;
+}
+.contents {
+  display: contents;
+}
+</style>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<div class="flex">
+P
+  <div class="contents">
+    <div>A</div>
+  </div>
+  <div class="contents">
+    <div class="inline">S<div>0</div></div>
+  </div>
+  <div class="contents">
+    S
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-001-none.html
+++ b/css-display-3/display-contents-dynamic-flex-001-none.html
@@ -14,9 +14,10 @@
 }
 .contents {
   display: contents;
+  border: 1px solid red;
 }
 </style>
-<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S", and no red</p>
 <div class="flex">
 P
   <div class="contents">

--- a/css-display-3/display-contents-dynamic-flex-002-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-002-inline.html
@@ -11,17 +11,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div>
 <script>
 window.onload = function() {

--- a/css-display-3/display-contents-dynamic-flex-002-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-002-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-dynamic-flex-002-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-002-inline.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div class="flex c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-002-none.html
+++ b/css-display-3/display-contents-dynamic-flex-002-none.html
@@ -11,17 +11,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div>
 <script>
 window.onload = function() {

--- a/css-display-3/display-contents-dynamic-flex-002-none.html
+++ b/css-display-3/display-contents-dynamic-flex-002-none.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div class="flex c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-002-none.html
+++ b/css-display-3/display-contents-dynamic-flex-002-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-dynamic-flex-003-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-003-inline.html
@@ -11,17 +11,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
-  <div class=""><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c4">4</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div></div>
 <script>
 window.onload = function() {

--- a/css-display-3/display-contents-dynamic-flex-003-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-003-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-dynamic-flex-003-inline.html
+++ b/css-display-3/display-contents-dynamic-flex-003-inline.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div class="flex"><div class="contents c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class=""><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div></div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-003-none.html
+++ b/css-display-3/display-contents-dynamic-flex-003-none.html
@@ -11,17 +11,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
-  <div class=""><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c4">4</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div></div>
 <script>
 window.onload = function() {

--- a/css-display-3/display-contents-dynamic-flex-003-none.html
+++ b/css-display-3/display-contents-dynamic-flex-003-none.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div class="flex"><div class="contents c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class=""><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div></div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-flex-003-none.html
+++ b/css-display-3/display-contents-dynamic-flex-003-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-dynamic-inline-flex-001-inline.html
+++ b/css-display-3/display-contents-dynamic-inline-flex-001-inline.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in inline-flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-inline-flex-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="iflex"><div class="contents c2">
+  0
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="contents c1">1</div>
+  2
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="c1">1</div>
+  2
+  </div></div>
+  <div class="iflex c3">
+  0
+  <div class="contents c2"><div class="c1">1</div></div>
+  2
+  </div>
+  <div class="iflex c3">
+  <div class="contents c2">0</div>
+  <div class="contents c2"><div class="c1">1</div></div>
+  <div class="contents c2">2</div>
+  </div>
+  <div class="iflex c3">
+  <div class="inline">0</div>
+  <div class="contents"><div class="inline c1">1</div></div>
+  <div class="inline">2</div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-inline-flex-001-inline.html
+++ b/css-display-3/display-contents-dynamic-inline-flex-001-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in inline-flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-inline-flex-001-ref.html">

--- a/css-display-3/display-contents-dynamic-inline-flex-001-none.html
+++ b/css-display-3/display-contents-dynamic-inline-flex-001-none.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in inline-flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-inline-flex-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="iflex"><div class="contents c2">
+  0
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="contents c1">1</div>
+  2
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="c1">1</div>
+  2
+  </div></div>
+  <div class="iflex c3">
+  0
+  <div class="contents c2"><div class="c1">1</div></div>
+  2
+  </div>
+  <div class="iflex c3">
+  <div class="contents c2">0</div>
+  <div class="contents c2"><div class="c1">1</div></div>
+  <div class="contents c2">2</div>
+  </div>
+  <div class="iflex c3">
+  <div class="inline">0</div>
+  <div class="contents"><div class="inline c1">1</div></div>
+  <div class="inline">2</div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-inline-flex-001-none.html
+++ b/css-display-3/display-contents-dynamic-inline-flex-001-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in inline-flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-inline-flex-001-ref.html">

--- a/css-display-3/display-contents-dynamic-list-001-inline.html
+++ b/css-display-3/display-contents-dynamic-list-001-inline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in list layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-list-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <ul><li class="c1"><div class="contents c2">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+  </div></li></ul>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-list-001-inline.html
+++ b/css-display-3/display-contents-dynamic-list-001-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in list layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-list-001-ref.html">

--- a/css-display-3/display-contents-dynamic-list-001-inline.html
+++ b/css-display-3/display-contents-dynamic-list-001-inline.html
@@ -12,17 +12,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
   </div></li></ul>
 </div>
 <script>

--- a/css-display-3/display-contents-dynamic-list-001-none.html
+++ b/css-display-3/display-contents-dynamic-list-001-none.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in list layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-list-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <ul><li class="c1"><div class="contents c2">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+  </div></li></ul>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-list-001-none.html
+++ b/css-display-3/display-contents-dynamic-list-001-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in list layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-list-001-ref.html">

--- a/css-display-3/display-contents-dynamic-list-001-none.html
+++ b/css-display-3/display-contents-dynamic-list-001-none.html
@@ -12,17 +12,17 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
   </div></li></ul>
 </div>
 <script>

--- a/css-display-3/display-contents-dynamic-multicol-001-inline.html
+++ b/css-display-3/display-contents-dynamic-multicol-001-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in multicolumn layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-multicol-001-ref.html">

--- a/css-display-3/display-contents-dynamic-multicol-001-inline.html
+++ b/css-display-3/display-contents-dynamic-multicol-001-inline.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in multicolumn layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-multicol-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="columns">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+
+  <div class="columns">
+  <div class="columns contents">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-multicol-001-none.html
+++ b/css-display-3/display-contents-dynamic-multicol-001-none.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in multicolumn layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-multicol-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="columns">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+
+  <div class="columns">
+  <div class="columns contents">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(document, window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = ''; })
+}
+</script>

--- a/css-display-3/display-contents-dynamic-multicol-001-none.html
+++ b/css-display-3/display-contents-dynamic-multicol-001-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in multicolumn layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-multicol-001-ref.html">

--- a/css-display-3/display-contents-dynamic-table-001-inline.html
+++ b/css-display-3/display-contents-dynamic-table-001-inline.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="cell">3</div></div>
+  <div class="contents c4"><div class="rowg">4</div></div>
+  <div class="contents c5"><div class="cell">5a</div></div>
+  <div class="cell c5">5b</div>
+  <div class="contents c6"><div class="head">6</div></div>
+  <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c8"><div class="cell">7b</div></div>
+  <div class="contents c9"><div class="foot">8</div></div>
+  <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="cell">10</div></div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(
+      document,
+      window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = 'contents'; });
+}
+</script>

--- a/css-display-3/display-contents-dynamic-table-001-inline.html
+++ b/css-display-3/display-contents-dynamic-table-001-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-001-ref.html">

--- a/css-display-3/display-contents-dynamic-table-001-none.html
+++ b/css-display-3/display-contents-dynamic-table-001-none.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="cell">3</div></div>
+  <div class="contents c4"><div class="rowg">4</div></div>
+  <div class="contents c5"><div class="cell">5a</div></div>
+  <div class="cell c5">5b</div>
+  <div class="contents c6"><div class="head">6</div></div>
+  <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c8"><div class="cell">7b</div></div>
+  <div class="contents c9"><div class="foot">8</div></div>
+  <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="cell">10</div></div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(
+      document,
+      window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = 'contents'; });
+}
+</script>

--- a/css-display-3/display-contents-dynamic-table-001-none.html
+++ b/css-display-3/display-contents-dynamic-table-001-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-001-ref.html">

--- a/css-display-3/display-contents-dynamic-table-002-inline.html
+++ b/css-display-3/display-contents-dynamic-table-002-inline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="table" style="float:right">
+    <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+    <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+    <div class="contents c3"><div class="cell">3</div></div>
+    <div class="contents c4"><div class="rowg">4</div></div>
+    <div class="contents c5"><div class="cell">5a</div></div>
+    <div class="cell c5">5b</div>
+    <div class="contents c6"><div class="head">6</div></div>
+    <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+    <div class="contents c8"><div class="cell">7b</div></div>
+    <div class="contents c9"><div class="foot">8</div></div>
+    <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+    <div class="contents c10"><div class="cell">10</div></div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(
+      document,
+      window,
+      function(e) { e.style.display = 'inline'; },
+      function(e) { e.style.display = 'contents'; });
+}
+</script>

--- a/css-display-3/display-contents-dynamic-table-002-inline.html
+++ b/css-display-3/display-contents-dynamic-table-002-inline.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in table layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-002-ref.html">

--- a/css-display-3/display-contents-dynamic-table-002-none.html
+++ b/css-display-3/display-contents-dynamic-table-002-none.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<script src="support/util.js"></script>
+<div style="color: red">
+  <div class="table" style="float:right">
+    <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+    <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+    <div class="contents c3"><div class="cell">3</div></div>
+    <div class="contents c4"><div class="rowg">4</div></div>
+    <div class="contents c5"><div class="cell">5a</div></div>
+    <div class="cell c5">5b</div>
+    <div class="contents c6"><div class="head">6</div></div>
+    <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+    <div class="contents c8"><div class="cell">7b</div></div>
+    <div class="contents c9"><div class="foot">8</div></div>
+    <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+    <div class="contents c10"><div class="cell">10</div></div>
+  </div>
+</div>
+<script>
+window.onload = function() {
+  eachDisplayContentsElementIn(
+      document,
+      window,
+      function(e) { e.style.display = 'none'; },
+      function(e) { e.style.display = 'contents'; });
+}
+</script>

--- a/css-display-3/display-contents-dynamic-table-002-none.html
+++ b/css-display-3/display-contents-dynamic-table-002-none.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in table layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-002-ref.html">

--- a/css-display-3/display-contents-flex-001-ref.html
+++ b/css-display-3/display-contents-flex-001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<style>
+.flex {
+  display: flex;
+}
+.inline {
+  display: inline;
+}
+</style>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<div class="flex">
+P
+  <div>A</div>
+  <div class="inline">S<div>0</div></div>
+  S
+</div>

--- a/css-display-3/display-contents-flex-001-ref.html
+++ b/css-display-3/display-contents-flex-001-ref.html
@@ -10,7 +10,7 @@
   display: inline;
 }
 </style>
-<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S", and no red</p>
 <div class="flex">
 P
   <div>A</div>

--- a/css-display-3/display-contents-flex-001.html
+++ b/css-display-3/display-contents-flex-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: display: contents inside a flex container</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-001-ref.html">
+<style>
+.flex {
+  display: flex;
+}
+.inline {
+  display: inline;
+}
+.contents {
+  display: contents;
+}
+</style>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<div class="flex">
+P
+  <div class="contents">
+    <div>A</div>
+  </div>
+  <div class="contents">
+    <div class="inline">S<div>0</div></div>
+  </div>
+  <div class="contents">
+    S
+  </div>
+</div>

--- a/css-display-3/display-contents-flex-001.html
+++ b/css-display-3/display-contents-flex-001.html
@@ -13,9 +13,10 @@
 }
 .contents {
   display: contents;
+  border: 1px solid red;
 }
 </style>
-<p>Test passes if you see the word "PASS", with a "0" under the first "S"</p>
+<p>Test passes if you see the word "PASS", with a "0" under the first "S", and no red</p>
 <div class="flex">
 P
   <div class="contents">

--- a/css-display-3/display-contents-flex-002-ref.html
+++ b/css-display-3/display-contents-flex-002-ref.html
@@ -9,18 +9,18 @@
     0&nbsp;
     <div class="inline c1">x&nbsp;</div>
     <div class="inline c1"><div class="inline c2">y</div></div>
-    <div class="inline c1"><div class="inline c2"><div class="">1<span>1</span></div></div></div>
-    <div class="inline c2"><div class="inline">2a<div class="">2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
+    <div class="inline c1"><div class="inline c2"><div>1<span>1</span></div></div></div>
+    <div class="inline c2"><div class="inline">2a<div>2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
     <div class="c3">3</div>
     <div class="inline"><div class="inline c4">4</div></div>
-    <div class=""><div class="inline c5">5a</div></div>
-    <div class=" c5">5b</div>
-    <div class="inline c6"><div class="">6</div></div>
+    <div><div class="inline c5">5a</div></div>
+    <div class="c5">5b</div>
+    <div class="inline c6"><div>6</div></div>
     <div class="ib"><div class="inline c7"><div class="inline c2">7<span class="b">a</span></div></div></div>
-    <div class="inline c9"><div class="">8</div></div>
+    <div class="inline c9"><div>8</div></div>
     <div class="inline c9"><div class="inline">9<div class="inline c2">a</div></div></div>
     <span class="c2 b">b</span>
     <div class="inline c2">c</div>
-    <div class="inline c10"><div class="">10</div></div>
+    <div class="inline c10"><div>10</div></div>
   </div>
 </div>

--- a/css-display-3/display-contents-flex-002-ref.html
+++ b/css-display-3/display-contents-flex-002-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+  <div class="flex c1">
+    0&nbsp;
+    <div class="inline c1">x&nbsp;</div>
+    <div class="inline c1"><div class="inline c2">y</div></div>
+    <div class="inline c1"><div class="inline c2"><div class="">1<span>1</span></div></div></div>
+    <div class="inline c2"><div class="inline">2a<div class="">2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
+    <div class="c3">3</div>
+    <div class="inline"><div class="inline c4">4</div></div>
+    <div class=""><div class="inline c5">5a</div></div>
+    <div class=" c5">5b</div>
+    <div class="inline c6"><div class="">6</div></div>
+    <div class="ib"><div class="inline c7"><div class="inline c2">7<span class="b">a</span></div></div></div>
+    <div class="inline c9"><div class="">8</div></div>
+    <div class="inline c9"><div class="inline">9<div class="inline c2">a</div></div></div>
+    <span class="c2 b">b</span>
+    <div class="inline c2">c</div>
+    <div class="inline c10"><div class="">10</div></div>
+  </div>
+</div>

--- a/css-display-3/display-contents-flex-002-ref.html
+++ b/css-display-3/display-contents-flex-002-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-flex-002.html
+++ b/css-display-3/display-contents-flex-002.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-flex-002.html
+++ b/css-display-3/display-contents-flex-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div class="flex c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div>

--- a/css-display-3/display-contents-flex-002.html
+++ b/css-display-3/display-contents-flex-002.html
@@ -10,15 +10,15 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div>

--- a/css-display-3/display-contents-flex-003.html
+++ b/css-display-3/display-contents-flex-003.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-flex-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div class="flex"><div class="contents c1">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class=""><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+</div></div>

--- a/css-display-3/display-contents-flex-003.html
+++ b/css-display-3/display-contents-flex-003.html
@@ -10,15 +10,15 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
-  <div class=""><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c4">4</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
 </div></div>

--- a/css-display-3/display-contents-flex-003.html
+++ b/css-display-3/display-contents-flex-003.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-flex-002-ref.html">

--- a/css-display-3/display-contents-float-001.html
+++ b/css-display-3/display-contents-float-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: display:contents works on floated elements</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-pass-no-red-ref.html">
+<style>
+  div {
+    display: contents;
+    float: right;
+    background: red;
+  }
+</style>
+<p>You should see the word PASS and no red below.</p>
+<div>P<span>A</span>S<span>S</span></div>

--- a/css-display-3/display-contents-inline-flex-001-ref.html
+++ b/css-display-3/display-contents-inline-flex-001-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+<div class="iflex"><div class="contents c2">
+0
+</div></div>
+<div class="iflex"><div class="contents c2">
+0
+<div class="inline c1">1</div>
+2
+</div></div>
+<div class="iflex"><div class="contents c2">
+0<div class="inline c1">1</div>2
+</div></div>
+<div class="iflex c3">
+0<div class="inline c2"><div class="c1">1</div></div>2
+</div>
+<div class="iflex c3">
+<div class="inline c2">0</div><div class="inline c2"><div class="c1">1</div></div><div class="inline c2">2</div>
+</div>
+<div class="iflex c3">
+<div class="inline">0</div>
+<div class="inline"><div class="inline c1">1</div></div>
+<div class="inline">2</div>
+</div>
+</div>

--- a/css-display-3/display-contents-inline-flex-001-ref.html
+++ b/css-display-3/display-contents-inline-flex-001-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-inline-flex-001.html
+++ b/css-display-3/display-contents-inline-flex-001.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in inline-flex layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-inline-flex-001-ref.html">

--- a/css-display-3/display-contents-inline-flex-001.html
+++ b/css-display-3/display-contents-inline-flex-001.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in inline-flex layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-inline-flex-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red">
+  <div class="iflex"><div class="contents c2">
+  0
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="contents c1">1</div>
+  2
+  </div></div>
+  <div class="iflex"><div class="contents c2">
+  0
+  <div class="c1">1</div>
+  2
+  </div></div>
+  <div class="iflex c3">
+  0
+  <div class="contents c2"><div class="c1">1</div></div>
+  2
+  </div>
+  <div class="iflex c3">
+  <div class="contents c2">0</div>
+  <div class="contents c2"><div class="c1">1</div></div>
+  <div class="contents c2">2</div>
+  </div>
+  <div class="iflex c3">
+  <div class="inline">0</div>
+  <div class="contents"><div class="inline c1">1</div></div>
+  <div class="inline">2</div>
+  </div>
+</div>

--- a/css-display-3/display-contents-list-001-ref.html
+++ b/css-display-3/display-contents-list-001-ref.html
@@ -9,17 +9,17 @@
   0
   <div class="inline c1">x</div>
   <div class="inline c1"><div class="inline c2">y</div></div>
-  <div class="inline c1"><div class="inline c2"><div class="">1<span>1</span></div></div></div>
-  <div class="inline c2"><div class="inline">2a<div class="">2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
+  <div class="inline c1"><div class="inline c2"><div>1<span>1</span></div></div></div>
+  <div class="inline c2"><div class="inline">2a<div>2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
   <div class="inline c3"><div class="inline">3</div></div>
   <div class="inline"><div class="inline c4">4</div></div>
-  <div class=""><div class="inline c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="inline c6"><div class="">6</div></div>
+  <div><div class="inline c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="inline c6"><div>6</div></div>
   <div class="ib"><div class="inline c7"><div class="inline c2">7<span class="b">a</span></div></div></div>
-  <div class="inline c9"><div class="">8</div></div>
+  <div class="inline c9"><div>8</div></div>
   <div class="inline c9"><div class="inline">9<div class="inline c2">a<span class="b">b</span>c</div></div></div>
-  <div class="inline c10"><div class="">10</div></div>
+  <div class="inline c10"><div>10</div></div>
   </div></li>
   </ul>
 </div>

--- a/css-display-3/display-contents-list-001-ref.html
+++ b/css-display-3/display-contents-list-001-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-list-001-ref.html
+++ b/css-display-3/display-contents-list-001-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+  <ul><li class="c1"><div class="inline c2">
+  0
+  <div class="inline c1">x</div>
+  <div class="inline c1"><div class="inline c2">y</div></div>
+  <div class="inline c1"><div class="inline c2"><div class="">1<span>1</span></div></div></div>
+  <div class="inline c2"><div class="inline">2a<div class="">2<div class="inline c2">b<span class="b">b</span></div></div></div></div>
+  <div class="inline c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="inline c4">4</div></div>
+  <div class=""><div class="inline c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="inline c6"><div class="">6</div></div>
+  <div class="ib"><div class="inline c7"><div class="inline c2">7<span class="b">a</span></div></div></div>
+  <div class="inline c9"><div class="">8</div></div>
+  <div class="inline c9"><div class="inline">9<div class="inline c2">a<span class="b">b</span>c</div></div></div>
+  <div class="inline c10"><div class="">10</div></div>
+  </div></li>
+  </ul>
+</div>

--- a/css-display-3/display-contents-list-001.html
+++ b/css-display-3/display-contents-list-001.html
@@ -11,16 +11,16 @@
   0
   <div class="contents c1">x</div>
   <div class="contents c1"><div class="contents c2">y</div></div>
-  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
-  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div>2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
   <div class="contents c3"><div class="inline">3</div></div>
   <div class="inline"><div class="contents c4">4</div></div>
-  <div class=""><div class="contents c5">5a</div></div>
-  <div class=" c5">5b</div>
-  <div class="contents c6"><div class="">6</div></div>
+  <div><div class="contents c5">5a</div></div>
+  <div class="c5">5b</div>
+  <div class="contents c6"><div>6</div></div>
   <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
-  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div>8</div></div>
   <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
-  <div class="contents c10"><div class="">10</div></div>
+  <div class="contents c10"><div>10</div></div>
   </div></li></ul>
 </div>

--- a/css-display-3/display-contents-list-001.html
+++ b/css-display-3/display-contents-list-001.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display: contents in list layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-list-001-ref.html">

--- a/css-display-3/display-contents-list-001.html
+++ b/css-display-3/display-contents-list-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display: contents in list layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-list-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red">
+  <ul><li class="c1"><div class="contents c2">
+  0
+  <div class="contents c1">x</div>
+  <div class="contents c1"><div class="contents c2">y</div></div>
+  <div class="contents c1"><div class="contents c2"><div class="">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="inline">2a<div class="">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="inline">3</div></div>
+  <div class="inline"><div class="contents c4">4</div></div>
+  <div class=""><div class="contents c5">5a</div></div>
+  <div class=" c5">5b</div>
+  <div class="contents c6"><div class="">6</div></div>
+  <div class="ib"><div class="contents c7"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c9"><div class="">8</div></div>
+  <div class="contents c9"><div class="contents">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="">10</div></div>
+  </div></li></ul>
+</div>

--- a/css-display-3/display-contents-multicol-001-ref.html
+++ b/css-display-3/display-contents-multicol-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+  <div class="columns">
+  <div class="contents c1"><div class="contents c2"><div>1<span>1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+
+  <div class="columns">
+  <div class="contents c1"><div class="contents c2"><div>1<span>1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+</div>

--- a/css-display-3/display-contents-multicol-001-ref.html
+++ b/css-display-3/display-contents-multicol-001-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-multicol-001.html
+++ b/css-display-3/display-contents-multicol-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in multicolumn layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-multicol-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red">
+  <div class="columns">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+
+  <div class="columns">
+  <div class="columns contents">
+  <div class="contents c1"><div class="contents c2"><div>1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div>2</div></div>
+  <div class="contents c3"><div>3</div></div>
+  </div>
+  </div>
+</div>

--- a/css-display-3/display-contents-multicol-001.html
+++ b/css-display-3/display-contents-multicol-001.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in multicolumn layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-multicol-001-ref.html">

--- a/css-display-3/display-contents-oof-001.html
+++ b/css-display-3/display-contents-oof-001.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: display:contents works on out-of-flow positioned elements</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-pass-no-red-ref.html">
+<style>
+  div {
+    display: contents;
+    position: absolute;
+    right: 0;
+    background: red;
+  }
+</style>
+<p>You should see the word PASS and no red below.</p>
+<div>P<span>A</span>S<span>S</span></div>

--- a/css-display-3/display-contents-oof-002.html
+++ b/css-display-3/display-contents-oof-002.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: display:contents works on out-of-flow positioned elements</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-pass-no-red-ref.html">
+<style>
+  div {
+    display: contents;
+    position: fixed;
+    right: 0;
+    background: red;
+  }
+</style>
+<p>You should see the word PASS and no red below.</p>
+<div>P<span>A</span>S<span>S</span></div>

--- a/css-display-3/display-contents-table-001-ref.html
+++ b/css-display-3/display-contents-table-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+  <div class="caption c2">1<span>1</span></div>
+  <div class="row c2">2a<div class="cell">2<div class="inline c2">b<span class="b">b</span></div></div></div>
+  <div class="cell c3">3</div>
+  <div class="rowg c4">4</div>
+  <div class="cell c5">5a</div>
+  <div class="cell c5">5b</div>
+  <div class="head c6">6</div>
+  <div class="cell c7"><div class="inline c2">7<span class="b">a</span></div></div>
+  <div class="cell c8">7b</div>
+  <div class="foot c9">8</div>
+  <div class="foot c9">9<div class="inline c2">a<span class="b">b</span>c</div></div>
+  <div class="cell c10">10</div>
+</div>

--- a/css-display-3/display-contents-table-001-ref.html
+++ b/css-display-3/display-contents-table-001-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-table-001.html
+++ b/css-display-3/display-contents-table-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-001-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red">
+  <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+  <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+  <div class="contents c3"><div class="cell">3</div></div>
+  <div class="contents c4"><div class="rowg">4</div></div>
+  <div class="contents c5"><div class="cell">5a</div></div>
+  <div class="cell c5">5b</div>
+  <div class="contents c6"><div class="head">6</div></div>
+  <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+  <div class="contents c8"><div class="cell">7b</div></div>
+  <div class="contents c9"><div class="foot">8</div></div>
+  <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+  <div class="contents c10"><div class="cell">10</div></div>
+</div>

--- a/css-display-3/display-contents-table-001.html
+++ b/css-display-3/display-contents-table-001.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in table layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-001-ref.html">

--- a/css-display-3/display-contents-table-002-ref.html
+++ b/css-display-3/display-contents-table-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red" class="ref">
+  <div class="table" style="float:right">
+    <div class="caption c2">1<span>1</span></div>
+    <div class="row c2">2a<div class="cell">2<div class="inline c2">b<span class="b">b</span></div></div></div>
+    <div class="cell c3" style="border:none">3</div>
+    <div class="rowg c4">4</div>
+    <div class="cell c5" style="border:none">5a</div>
+    <div class="cell c5">5b</div>
+    <div class="head c6">6</div>
+    <div class="cell c7" style="border:none"><div class="inline c2">7<span class="b">a</span></div></div>
+    <div class="cell c8" style="border:none">7b</div>
+    <div class="foot c9" style="border:none">8</div>
+    <div class="foot c9">9<div class="inline c2">a<span class="b">b</span>c</div></div>
+    <div class="cell c10" style="border:none">10</div>
+  </div>
+</div>
+

--- a/css-display-3/display-contents-table-002-ref.html
+++ b/css-display-3/display-contents-table-002-ref.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reftest Reference</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="stylesheet" href="support/acid.css">
 <div style="color: red" class="ref">

--- a/css-display-3/display-contents-table-002.html
+++ b/css-display-3/display-contents-table-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-table-002-ref.html">
+<link rel="stylesheet" href="support/acid.css">
+<div style="color: red">
+  <div class="table" style="float:right">
+    <div class="contents c1"><div class="contents c2"><div class="caption">1<span class="b">1</span></div></div></div>
+    <div class="contents c2"><div class="row">2a<div class="cell">2<div class="contents c2">b<span class="b">b</span></div></div></div></div>
+    <div class="contents c3"><div class="cell">3</div></div>
+    <div class="contents c4"><div class="rowg">4</div></div>
+    <div class="contents c5"><div class="cell">5a</div></div>
+    <div class="cell c5">5b</div>
+    <div class="contents c6"><div class="head">6</div></div>
+    <div class="contents c7"><div class="cell"><div class="contents c2">7<span class="b">a</span></div></div></div>
+    <div class="contents c8"><div class="cell">7b</div></div>
+    <div class="contents c9"><div class="foot">8</div></div>
+    <div class="contents c9"><div class="foot">9<div class="contents c2">a<span class="b">b</span>c</div></div></div>
+    <div class="contents c10"><div class="cell">10</div></div>
+  </div>
+</div>

--- a/css-display-3/display-contents-table-002.html
+++ b/css-display-3/display-contents-table-002.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Test: CSS display:contents in table layout</title>
-<link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=907396">
+<!-- Imported from: https://bugzilla.mozilla.org/show_bug.cgi?id=907396 -->
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
 <link rel="match" href="display-contents-table-002-ref.html">

--- a/css-display-3/display-contents-text-only-001-ref.html
+++ b/css-display-3/display-contents-text-only-001-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<style>
+  html, body { margin: 0; padding: 0; }
+</style>
+<p>Test passes if you see the word "PASS" below</p>
+PASS

--- a/css-display-3/display-contents-text-only-001.html
+++ b/css-display-3/display-contents-text-only-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: Only text on a display: contents subtree</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-text-only-001-ref.html">
+<style>
+  body { display: contents; }
+</style>
+<p>Test passes if you see the word "PASS" below</p>
+PASS

--- a/css-display-3/support/acid.css
+++ b/css-display-3/support/acid.css
@@ -49,3 +49,7 @@ html, body {
 .c9 { color: grey; }
 .c10{ color: black; }
 .b { background: inherit; }
+
+/** This is the only difference between references and non-reference styles */
+.ref .c2 { background: transparent; }
+.ref .b { background:blue; }

--- a/css-display-3/support/acid.css
+++ b/css-display-3/support/acid.css
@@ -55,3 +55,5 @@ body { color: red; }
 /** This is the only difference between references and non-reference styles */
 .ref .c2 { background: transparent; }
 .ref .b { background:blue; }
+.ref div.contents { display: block; }
+.ref span.contents { display: inline; }

--- a/css-display-3/support/acid.css
+++ b/css-display-3/support/acid.css
@@ -1,0 +1,51 @@
+html, body {
+  color: black;
+  background-color: white;
+  font-size: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.table {
+  display: table;
+  border-collapse: collapse;
+  border: blue solid 1pt;
+}
+
+.itable { display: inline-table; }
+.caption { display: table-caption; }
+.cell {
+  display: table-cell;
+  border: inherit;
+}
+.row {
+  display: table-row;
+  border: green dashed 1pt;
+}
+.rowg { display: table-row-group; }
+.head { display: table-header-group; }
+.foot { display: table-footer-group; }
+.col { display: table-column; }
+.colg { display: table-column-group; }
+.flex { display: flex; }
+.iflex { display: inline-flex; }
+.li { display: list-item; }
+.ib { display: inline-block; }
+.inline { display: inline; }
+.columns { columns: 2; height: 4em; }
+.contents {
+  display: contents;
+  align-items: inherit;
+  justify-items:inherit;
+}
+.c1 { color: lime; }
+.c2 { background: blue; color: pink; }
+.c3 { color: teal; }
+.c4 { color: green; }
+.c5 { color: silver; }
+.c6 { color: cyan; }
+.c7 { color: magenta; }
+.c8 { color: yellow; }
+.c9 { color: grey; }
+.c10{ color: black; }
+.b { background: inherit; }

--- a/css-display-3/support/acid.css
+++ b/css-display-3/support/acid.css
@@ -6,6 +6,8 @@ html, body {
   margin: 0;
 }
 
+body { color: red; }
+
 .table {
   display: table;
   border-collapse: collapse;

--- a/css-display-3/support/util.js
+++ b/css-display-3/support/util.js
@@ -1,0 +1,23 @@
+function eachDisplayContentsElementIn(document, window, callbackDo, callbackUndo) {
+  var elements = [];
+
+  document.body.offsetHeight;
+
+  // NOTE: Doing qsa('*') and getComputedStyle is just for the
+  // test's sake, since it's easier to mess it up when
+  // getComputedStyle is involved.
+  var all = document.querySelectorAll('*');
+  for (var i = 0; i < all.length; ++i) {
+    if (window.getComputedStyle(all[i]).display === "contents") {
+      callbackDo(all[i]);
+      elements.push(all[i]);
+    }
+  }
+
+  document.body.offsetHeight;
+
+  for (var i = 0; i < elements.length; ++i)
+    callbackUndo(elements[i]);
+
+  document.body.offsetHeight;
+}


### PR DESCRIPTION
This imports an splitted version of mozilla's [display: contents acid test](http://searchfox.org/mozilla-central/source/layout/reftests/css-display/display-contents-acid.html), and adds tests for dynamic changes to display: contents elements in a variety of situations both from and to `display: none` and `display: inline`.

I'm aware that there's a bunch of duplication, though adding a bunch of iframes for this seemed overkill. Let me know if you think it's fine, or otherwise what's the best way to move this forward. I really like more minimal tests, but these tests test a variety of hard-to-find-otherwise situations.

Could you take a look @rune-opera? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1155)
<!-- Reviewable:end -->
