### PR TITLE
[css-ui] Verify caret-color animations

### DIFF
--- a/css-ui-3/caret-color-019.html
+++ b/css-ui-3/caret-color-019.html
@@ -32,11 +32,7 @@
 
         var player = textarea.animate(keyframes, options);
         player.pause();
-        player.currentTime = 0;
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 255)');
         player.currentTime = 5;
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
-        player.currentTime = 10;
         assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
       }, "caret-color: auto is not interpolatible");
 </script>

--- a/css-ui-3/caret-color-019.html
+++ b/css-ui-3/caret-color-019.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Basic User Interface Test: caret-color auto test animation</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#caret-color">
+<link rel="help" href="https://www.w3.org/TR/web-animations-1/#dom-animatable-animate">
+<link rel="help" href="https://www.w3.org/TR/css3-color/#color0">
+<meta name="assert" content="Test checks that 'auto' value for caret-color property is not interpolatible.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  textarea {
+    color: magenta;
+    caret-color: red;
+  }
+</style>
+<body>
+  <textarea id="textarea"></textarea>
+  <div id=log></div>
+
+  <script>
+    test(
+      function(){
+        var textarea = document.getElementById("textarea");
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 0)');
+
+        var keyframes = [
+          { caretColor: 'auto' },
+          { caretColor: 'lime' }
+        ];
+        var options = {
+          duration: 10,
+          fill: "forwards"
+        };
+
+        var player = textarea.animate(keyframes, options);
+        player.pause();
+        player.currentTime = 0;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 255)');
+        player.currentTime = 5;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
+        player.currentTime = 10;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
+      }, "caret-color: auto is not interpolatible");
+</script>
+</body>

--- a/css-ui-3/caret-color-019.html
+++ b/css-ui-3/caret-color-019.html
@@ -11,7 +11,6 @@
 <style>
   textarea {
     color: magenta;
-    caret-color: red;
   }
 </style>
 <body>
@@ -22,8 +21,6 @@
     test(
       function(){
         var textarea = document.getElementById("textarea");
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 0)');
-
         var keyframes = [
           { caretColor: 'auto' },
           { caretColor: 'lime' }

--- a/css-ui-3/caret-color-020.html
+++ b/css-ui-3/caret-color-020.html
@@ -11,7 +11,6 @@
 <style>
   textarea {
     color: magenta;
-    caret-color: red;
   }
 </style>
 <body>
@@ -22,8 +21,6 @@
     test(
       function(){
         var textarea = document.getElementById("textarea");
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 0)');
-
         var keyframes = [
           { caretColor: 'currentcolor' },
           { caretColor: 'lime' }

--- a/css-ui-3/caret-color-020.html
+++ b/css-ui-3/caret-color-020.html
@@ -32,12 +32,8 @@
 
         var player = textarea.animate(keyframes, options);
         player.pause();
-        player.currentTime = 0;
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 255)');
         player.currentTime = 5;
         assert_equals(getComputedStyle(textarea).caretColor, 'rgb(128, 128, 128)');
-        player.currentTime = 10;
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
       }, "caret-color: currentcolor is interpolatible");
 </script>
 </body>

--- a/css-ui-3/caret-color-020.html
+++ b/css-ui-3/caret-color-020.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Basic User Interface Test: caret-color currentcolor test animation</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#caret-color">
+<link rel="help" href="https://www.w3.org/TR/web-animations-1/#dom-animatable-animate">
+<link rel="help" href="https://www.w3.org/TR/css3-color/#color0">
+<meta name="assert" content="Test checks that 'currentcolor' value for caret-color property is interpolatible.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  textarea {
+    color: magenta;
+    caret-color: red;
+  }
+</style>
+<body>
+  <textarea id="textarea"></textarea>
+  <div id=log></div>
+
+  <script>
+    test(
+      function(){
+        var textarea = document.getElementById("textarea");
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 0)');
+
+        var keyframes = [
+          { caretColor: 'currentcolor' },
+          { caretColor: 'lime' }
+        ];
+        var options = {
+          duration: 10,
+          fill: "forwards"
+        };
+
+        var player = textarea.animate(keyframes, options);
+        player.pause();
+        player.currentTime = 0;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(255, 0, 255)');
+        player.currentTime = 5;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(128, 128, 128)');
+        player.currentTime = 10;
+        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
+      }, "caret-color: currentcolor is interpolatible");
+</script>
+</body>


### PR DESCRIPTION
Added 2 new tests to check that "caret-color: auto" isn't interpolatible,
but "caret-color: currentcolor" is.

See w3c/csswg-drafts#781 for more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1162)
<!-- Reviewable:end -->
