### PR TITLE
[css-fonts-3] Fix trailing whitespace in test-synthetic-italic.xht

### DIFF
--- a/css-fonts-3/test-synthetic-italic.xht
+++ b/css-fonts-3/test-synthetic-italic.xht
@@ -10,7 +10,7 @@
         <meta name="assert" content="Synthetic italic text should render differently than normal text" />
         <style type="text/css">
             div { font-size: 36px; }
-            span#verify {font-family: "CSSTest Verify";} 
+            span#verify {font-family: "CSSTest Verify";}
             div#test1 {
                 font-family: CSSTest Verify;
             }


### PR DESCRIPTION
This was introduced in cb0aa483996c75c6f4a8dc1c08a1e3a78d996e01.

@svgeesus introduced this trailing whitespace by mistake, and it's causing Tavis failures (e.g. https://travis-ci.org/w3c/csswg-test/jobs/185842710).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1164)
<!-- Reviewable:end -->
