### PR TITLE
[css-ui] Fix typo in some caret-color tests

### DIFF
--- a/css-ui-3/caret-color-019.html
+++ b/css-ui-3/caret-color-019.html
@@ -5,7 +5,7 @@
 <link rel="help" href="http://www.w3.org/TR/css3-ui/#caret-color">
 <link rel="help" href="https://www.w3.org/TR/web-animations-1/#dom-animatable-animate">
 <link rel="help" href="https://www.w3.org/TR/css3-color/#color0">
-<meta name="assert" content="Test checks that 'auto' value for caret-color property is not interpolatible.">
+<meta name="assert" content="Test checks that 'auto' value for caret-color property is not interpolable.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
@@ -34,6 +34,6 @@
         player.pause();
         player.currentTime = 5;
         assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
-      }, "caret-color: auto is not interpolatible");
+      }, "caret-color: auto is not interpolable");
 </script>
 </body>

--- a/css-ui-3/caret-color-020.html
+++ b/css-ui-3/caret-color-020.html
@@ -5,7 +5,7 @@
 <link rel="help" href="http://www.w3.org/TR/css3-ui/#caret-color">
 <link rel="help" href="https://www.w3.org/TR/web-animations-1/#dom-animatable-animate">
 <link rel="help" href="https://www.w3.org/TR/css3-color/#color0">
-<meta name="assert" content="Test checks that 'currentcolor' value for caret-color property is interpolatible.">
+<meta name="assert" content="Test checks that 'currentcolor' value for caret-color property is interpolable.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
@@ -34,6 +34,6 @@
         player.pause();
         player.currentTime = 5;
         assert_equals(getComputedStyle(textarea).caretColor, 'rgb(128, 128, 128)');
-      }, "caret-color: currentcolor is interpolatible");
+      }, "caret-color: currentcolor is interpolable");
 </script>
 </body>

--- a/css-ui-3/caret-color-021.html
+++ b/css-ui-3/caret-color-021.html
@@ -27,7 +27,7 @@
       function(){
         var textarea = document.getElementById("textarea");
         assert_equals(getComputedStyle(textarea).caretColor, 'rgb(0, 255, 0)');
-      }, "Default caret-color is not interpolatible");
+      }, "Default caret-color is not interpolable");
 </script>
 </body>
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1166)
<!-- Reviewable:end -->
