### PR TITLE
Remove `end` keyword from transition-timing-function serialization

### DIFF
--- a/css-transitions-1/transition-timing-function-001.html
+++ b/css-transitions-1/transition-timing-function-001.html
@@ -59,15 +59,15 @@
                 'ease-out': 'cubic-bezier(0, 0, 0.58, 1)',
                 'ease-in-out': 'cubic-bezier(0.42, 0, 0.58, 1)',
                 'step-start': 'steps(1, start)',
-                'step-end': 'steps(1, end)',
+                'step-end': 'steps(1)',
                 // cubic bezier
                 'cubic-bezier(0.1, 0.2, 0.3, 0.4)': 'cubic-bezier(0.1, 0.2, 0.3, 0.4)',
                 'cubic-bezier(0.1, -0.2, 0.3, -0.4)': 'cubic-bezier(0.1, -0.2, 0.3, -0.4)',
                 'cubic-bezier(0.1, 1.2, 0.3, 1.4)': 'cubic-bezier(0.1, 1.2, 0.3, 1.4)',
                 // steps
                 'steps(3, start)': 'steps(3, start)',
-                'steps(3, end)': 'steps(3, end)',
-                'steps(3)': 'steps(3, end)',
+                'steps(3, end)': 'steps(3)',
+                'steps(3)': 'steps(3)',
                 // invalid
                 'cubic-bezier(foobar)': defaultValue,
                 'steps(foobar)': defaultValue,


### PR DESCRIPTION
According to spec, if the point at which the value changes is `end`, `transition-timing-function` should be  serialized as steps(\<integer\>). But tests don't reflect that.
Spec link: https://drafts.csswg.org/css-transitions/#serializing-a-timing-function

cc @Manishearth 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1168)
<!-- Reviewable:end -->
