### PR TITLE
[css-ui] Avoid autofocus on caret-color tests

### DIFF
--- a/css-ui-3/caret-color-001.html
+++ b/css-ui-3/caret-color-001.html
@@ -20,5 +20,10 @@
 <body>
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is green.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-002.html
+++ b/css-ui-3/caret-color-002.html
@@ -22,6 +22,11 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is green.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
   <div>
-    <textarea autofocus></textarea>
+    <textarea id="test"></textarea>
   </div>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-003.html
+++ b/css-ui-3/caret-color-003.html
@@ -22,5 +22,10 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is green,
   like the text in that textarea.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-004.html
+++ b/css-ui-3/caret-color-004.html
@@ -21,5 +21,10 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is either black
   or some other color that contrasts well with the background.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-005.html
+++ b/css-ui-3/caret-color-005.html
@@ -21,5 +21,10 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is either white
   or some other color that contrasts well with the background.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-006.html
+++ b/css-ui-3/caret-color-006.html
@@ -21,5 +21,10 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is
   any color that contrasts well with the background.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-007.html
+++ b/css-ui-3/caret-color-007.html
@@ -26,6 +26,11 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is green</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
   <div>
-    <textarea autofocus></textarea>
+    <textarea id="test"></textarea>
   </div>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-008.html
+++ b/css-ui-3/caret-color-008.html
@@ -29,5 +29,10 @@
 <body>
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret continuously changes colors.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <textarea autofocus></textarea>
+  <textarea id="test"></textarea>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-010.html
+++ b/css-ui-3/caret-color-010.html
@@ -19,5 +19,10 @@
 <body>
   <p>Test passes if, when the input field below is focused for editing, the text insertion caret is green.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
-  <input autofocus></input>
+  <input id="test"></input>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>

--- a/css-ui-3/caret-color-012.html
+++ b/css-ui-3/caret-color-012.html
@@ -24,6 +24,11 @@
   <p>Test passes if, when the text area below is focused for editing, the text insertion caret is green.</p>
   <p>The shape of the caret, and whether it flashes, are not part of the test.</p>
   <div>
-    <textarea autofocus></textarea>
+    <textarea id="test"></textarea>
   </div>
+  <script>
+    window.onload = function() {
+      document.getElementById("test").focus();
+    }
+  </script>
 </body>


### PR DESCRIPTION

This change is needed for [running the tests on Blink](https://codereview.chromium.org/2605173002/). Main reason is that, in this Blink CL, the focusing step is performed after Document load and that's causing differences on the text expectations.

This is particular to Blink implementation, but using the proposed solution would solve it and it doesn't seem harmful (as we're not actually testing `autofocus` on these tests). It'd help to keep `csswg-tests` and Blink tests synchronized.
What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1169)
<!-- Reviewable:end -->
