### PR TITLE
[flexbox-1] Test cross-size determination if flex item has overflow: scroll

### DIFF
--- a/css-flexbox-1/layout-algorithm_algo-cross-line-001.html
+++ b/css-flexbox-1/layout-algorithm_algo-cross-line-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>CSS Grid Layout Test: cross size determination with overflow:scroll</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
+        <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#algo-cross-line" title="9.4. Cross Size Determination" />
+        <link rel="match" href="../reference/layout-algorithm_algo-cross-line-001-ref.html" />
+        <meta name="assert" content="This test checks that correct height is applied if overflow: scroll is set" />
+        <style type="text/css">
+            .flex {
+                width: 200px;
+                display: flex;
+                background: red;
+            }
+
+            .flex>* {
+                background: green;
+                height: 200px;
+                flex: 1;
+                overflow: scroll;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square with scrollbars and <strong>no red</strong>.</p>
+
+        <div class="flex">
+            <div></div>
+            <div></div>
+        </div>
+    </body>
+</html>

--- a/css-flexbox-1/layout-algorithm_algo-cross-line-001.html
+++ b/css-flexbox-1/layout-algorithm_algo-cross-line-001.html
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: cross size determination with overflow:scroll</title>
         <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
         <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#algo-cross-line" title="9.4. Cross Size Determination" />
-        <link rel="match" href="../reference/layout-algorithm_algo-cross-line-001-ref.html" />
+        <link rel="match" href="reference/layout-algorithm_algo-cross-line-001-ref.html" />
         <meta name="assert" content="This test checks that correct height is applied if overflow: scroll is set" />
         <style type="text/css">
             .flex {

--- a/css-flexbox-1/layout-algorithm_algo-cross-line-002.html
+++ b/css-flexbox-1/layout-algorithm_algo-cross-line-002.html
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: cross size determination with overflow:scroll</title>
         <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
         <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#algo-cross-line" title="9.4. Cross Size Determination" />
-        <link rel="match" href="../reference/layout-algorithm_algo-cross-line-002-ref.html" />
+        <link rel="match" href="reference/layout-algorithm_algo-cross-line-002-ref.html" />
         <meta name="assert" content="This test checks that correct width is applied if overflow: scroll is set" />
         <style type="text/css">
             .flex {

--- a/css-flexbox-1/layout-algorithm_algo-cross-line-002.html
+++ b/css-flexbox-1/layout-algorithm_algo-cross-line-002.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>CSS Grid Layout Test: cross size determination with overflow:scroll</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
+        <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#algo-cross-line" title="9.4. Cross Size Determination" />
+        <link rel="match" href="../reference/layout-algorithm_algo-cross-line-002-ref.html" />
+        <meta name="assert" content="This test checks that correct width is applied if overflow: scroll is set" />
+        <style type="text/css">
+            .flex {
+                width: 200px;
+                height: 200px;
+                display: flex;
+                background: red;
+                flex-direction: column;
+            }
+
+            .flex>* {
+                background: green;
+                width: 200px;
+                height: 100px;
+                overflow: scroll;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square with scrollbars and <strong>no red</strong>.</p>
+
+        <div class="flex">
+            <div></div><div></div>
+        </div>
+    </body>
+</html>

--- a/css-flexbox-1/reference/layout-algorithm_algo-cross-line-001-ref.html
+++ b/css-flexbox-1/reference/layout-algorithm_algo-cross-line-001-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>CSS Flex-basis Test</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
+        <style type="text/css">
+            .flex {
+                width: 200px;
+                height: 200px;
+            }
+
+            .flex > * {
+                background: green;
+                height: 200px;
+                width: 100px;
+                overflow: scroll;
+                display: inline-block;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square with scrollbars and <strong>no red</strong>.</p>
+
+        <div class="flex">
+            <div></div><div></div>
+        </div>
+    </body>
+</html>

--- a/css-flexbox-1/reference/layout-algorithm_algo-cross-line-002-ref.html
+++ b/css-flexbox-1/reference/layout-algorithm_algo-cross-line-002-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>CSS Flex-basis Test</title>
+        <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub+github@gmail.com">
+        <style type="text/css">
+            .flex {
+                width: 200px;
+                height: 200px;
+            }
+
+            .flex > * {
+                background: green;
+                height: 100px;
+                width: 200px;
+                overflow: scroll;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square with scrollbars and <strong>no red</strong>.</p>
+
+        <div class="flex">
+            <div></div><div></div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
According to [9.4. Cross Size Determination #8](https://www.w3.org/TR/css-flexbox-1/#algo-cross-line)

> If the flex container is single-line and has a definite cross size, the cross size of the flex line is the flex container’s inner cross size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1171)
<!-- Reviewable:end -->
