### PR TITLE
Travis should exit cleanly

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -268,6 +268,7 @@ class Builder(object):
                             self.ui.warn("WARNING: Test suite '", testSuiteName, "' references unknown specification: '", specName, "'.\n")
                 else:
                     self.ui.warn("ERROR: Test suite '", testSuiteName, "' does not have target specifications.\n")
+                    return -6
         else:
             self.ui.status("No test suites identified\n")
             return 0

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -95,6 +95,16 @@ def setup_virtualenv():
 def update_to_changeset(changeset):
     git = vcs.bind_to_repo(vcs.git, source_dir)
     git("checkout", changeset)
+    apply_build_system_fixes()
+
+def apply_build_system_fixes():
+    fixes = [
+        "c017547f65e07bdd889736524d47824d032ba2e8",
+        "cb4a737a88aa7e2f4e54383c57ffa2dfae093dcf"
+    ]
+    git = vcs.bind_to_repo(vcs.git, source_dir)
+    for fix in fixes:
+        git("cherry-pick", "--keep-redundant-commits", fix)
 
 def build_tests():
     subprocess.check_call(["python", os.path.join(source_dir, "tools", "build.py")],

--- a/tools/travis/build.py
+++ b/tools/travis/build.py
@@ -63,7 +63,7 @@ def fetch_submodules():
 def update_dist():
     if not os.path.exists(built_dir) or not vcs.is_git_root(built_dir):
         git = vcs.git
-        git("clone", remote_built, built_dir)
+        git("clone", "--depth", "1", remote_built, built_dir)
     else:
         git = vcs.bind_to_repo(vcs.git, built_dir)
         git("fetch")


### PR DESCRIPTION
Currently the build is failing and hanging in pdb. This is bad. All the other `ERROR` messages exit, so this should too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1175)
<!-- Reviewable:end -->
