### PR TITLE
Fix word-break-normal-zh-000.html

### DIFF
--- a/css-text-3/word-break/word-break-normal-zh-000.html
+++ b/css-text-3/word-break/word-break-normal-zh-000.html
@@ -16,7 +16,7 @@
 <body>
 <div id='instructions'>Test passes if the two orange boxes are the same.</div>
 <div class="test" lang="zh"><div id="testdiv"><span id="testspan">中國話中國話中國話</span></div></div>
-<div class="ref" lang="zh"><span>中國話中國話中國<br/>語</span></div>
+<div class="ref" lang="zh"><span>中國話中國話中國<br/>話</span></div>
 <script>
 var sentenceWidth = document.getElementById('testspan').offsetWidth
 document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'


### PR DESCRIPTION
The test had a different character in the reference case (語 instead of 話), and should have caused all browsers to fail this test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1178)
<!-- Reviewable:end -->
