### PR TITLE
Update wpt_tools to introduce the new CSS-mode lint

### DIFF
--- a/lint
+++ b/lint
@@ -8,4 +8,4 @@ except ImportError:
           '"git submodule update --init --recursive"?')
     sys.exit(2)
 
-sys.exit(0 if lint.main(True) == 0 else 1)
+sys.exit(0 if lint.main(force_css_mode=True) == 0 else 1)

--- a/lint
+++ b/lint
@@ -8,4 +8,4 @@ except ImportError:
           '"git submodule update --init --recursive"?')
     sys.exit(2)
 
-sys.exit(0 if lint.main() == 0 else 1)
+sys.exit(0 if lint.main(True) == 0 else 1)

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -57,6 +57,11 @@ CONSOLE: css-writing-modes-3/tools/generators/unicode-data.js
 *: work-in-progress/*
 
 
+## Test plans and implementation reports
+*: */reports/*
+*: */test-plan/*
+
+
 ## Things we don't have enabled yet
 OPEN-NO-MODE: *
 PARSE-FAILED: *
@@ -64,6 +69,42 @@ PRINT STATEMENT: *
 W3C-TEST.ORG: *
 CONTENT-VISUAL: *
 CONTENT-MANUAL: *
+
+
+## Support files not in /support/ or similar
+SUPPORT-WRONG-DIR: */reftest.list
+SUPPORT-WRONG-DIR: *.headers
+SUPPORT-WRONG-DIR: */README
+SUPPORT-WRONG-DIR: */README.md
+SUPPORT-WRONG-DIR: *-README
+SUPPORT-WRONG-DIR: */LICENSE
+SUPPORT-WRONG-DIR: */LICENSE-*
+SUPPORT-WRONG-DIR: */COPYING
+SUPPORT-WRONG-DIR: */Makefile
+
+# The selectors-3 testsuite has a weird build system
+SUPPORT-WRONG-DIR: selectors-3/*
+
+# Things we should fix
+SUPPORT-WRONG-DIR: css-animations-1/animationevent-interface.js
+SUPPORT-WRONG-DIR: css-backgrounds-3/justfortest.html
+SUPPORT-WRONG-DIR: css-backgrounds-3/background-clip/list.txt
+SUPPORT-WRONG-DIR: css-backgrounds-3/background-origin/list.txt
+SUPPORT-WRONG-DIR: css-color-3/htaccess
+SUPPORT-WRONG-DIR: css-fonts-3/font-variant-debug.html
+SUPPORT-WRONG-DIR: css-masking-1/clip-path/svg-clipPath.svg
+SUPPORT-WRONG-DIR: css21/section-index.xht
+SUPPORT-WRONG-DIR: css21/other-formats/xml/background-18.css
+SUPPORT-WRONG-DIR: css21/other-formats/xml/background-19-alt.xml
+SUPPORT-WRONG-DIR: css21/other-formats/xml/background-19.css
+SUPPORT-WRONG-DIR: filters-1/filter-external-002-filter.svg
+SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/check-for-references.sh
+SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/sync-tests-filter
+SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/sync-tests.sh
+SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/masking/blank.html
+SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/transforms/green.html
+SUPPORT-WRONG-DIR: WOFF2-UserAgent/manifest.txt
+SUPPORT-WRONG-DIR: WOFF2-UserAgent/Tests/xhtml1/testcaseindex.xht
 
 
 ## Whitespace rules that we can't enforce yet


### PR DESCRIPTION
Also add a bunch of whitelists for SUPPORT-WRONG-DIR now we have it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1184)
<!-- Reviewable:end -->
