### PR TITLE
Match word-break-normal-zh-000.html characters with reference

### DIFF
--- a/css-text-3/word-break/word-break-normal-zh-000.html
+++ b/css-text-3/word-break/word-break-normal-zh-000.html
@@ -15,8 +15,8 @@
 </head>
 <body>
 <div id='instructions'>Test passes if the two orange boxes are the same.</div>
-<div class="test" lang="zh"><div id="testdiv"><span id="testspan">中國話中國話中國話</span></div></div>
-<div class="ref" lang="zh"><span>中國話中國話中國<br/>話</span></div>
+<div class="test" lang="zh"><div id="testdiv"><span id="testspan">中國話中國話中國語</span></div></div>
+<div class="ref" lang="zh"><span>中國話中國話中國<br/>語</span></div>
 <script>
 var sentenceWidth = document.getElementById('testspan').offsetWidth
 document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'


### PR DESCRIPTION
I attempted a change in #1178 but realized that the reference test case used 語 instead of 話. This PR reverts that change and ensures that the characters in the test and ref are both the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1188)
<!-- Reviewable:end -->
