### PR TITLE
[css-ui-3] Fix HTTP headers

### DIFF
--- a/css-ui-3/support/cursors/.htaccess
+++ b/css-ui-3/support/cursors/.htaccess
@@ -1,0 +1,3 @@
+<Files "woolly-64.svgz">
+	Header set Content-Encoding gzip
+</Files>


### PR DESCRIPTION
[This previous patch](https://github.com/w3c/csswg-test/pull/1187) to fix this TC [did not work](https://lists.w3.org/Archives/Public/public-css-testsuite/2017Jan/0016.html). @plinss [explained](https://lists.w3.org/Archives/Public/public-css-testsuite/2017Jan/0017.html) that with the current server we need to do it using .htaccess instead of .headers files, so this patch does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1191)
<!-- Reviewable:end -->
