### PR TITLE
[css-grid] Update Grid Layout test suite

### DIFF
--- a/css-grid-1/grid-definition/grid-inline-support-flexible-lengths-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-flexible-lengths-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>
@@ -38,8 +40,6 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "400px", "300px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1fr)", "minmax(1fr, 1fr)", "800px", "600px");
@@ -98,6 +98,8 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "calc(1fr + 100px)", "calc(1fr + 100px)", "90px", "10px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "(1fr) auto", "(1fr) auto", "none", "none");
             TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
+            TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
         ]]></script>
     </body>
 </html>

--- a/css-grid-1/grid-definition/grid-inline-support-grid-template-columns-rows-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-grid-template-columns-rows-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-inline-support-named-grid-lines-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-named-grid-lines-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-inline-support-repeat-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-support-repeat-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-inline-template-columns-rows-resolved-values-001.xht
+++ b/css-grid-1/grid-definition/grid-inline-template-columns-rows-resolved-values-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
 
             .fifthColumn {

--- a/css-grid-1/grid-definition/grid-support-flexible-lengths-001.xht
+++ b/css-grid-1/grid-definition/grid-support-flexible-lengths-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>
@@ -38,8 +40,6 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "0.5fr", "0.5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", ".5fr", ".5fr", "400px", "300px");
             TestingUtils.testGridTemplateColumnsRows("grid", ".5fr", ".5fr", "400px", "300px");
-            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
-            TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 1fr)", "minmax(100px, 1fr)", "800px", "600px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1fr)", "minmax(1fr, 1fr)", "800px", "600px");
@@ -98,6 +98,8 @@
             TestingUtils.testGridTemplateColumnsRows("grid", "calc(1fr + 100px)", "calc(1fr + 100px)", "90px", "10px");
             TestingUtils.testGridTemplateColumnsRows("emptyGrid", "(1fr) auto", "(1fr) auto", "none", "none");
             TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
+            TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
+            TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
         ]]></script>
     </body>
 </html>

--- a/css-grid-1/grid-definition/grid-support-grid-template-columns-rows-001.xht
+++ b/css-grid-1/grid-definition/grid-support-grid-template-columns-rows-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-support-named-grid-lines-001.xht
+++ b/css-grid-1/grid-definition/grid-support-named-grid-lines-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-support-repeat-001.xht
+++ b/css-grid-1/grid-definition/grid-support-repeat-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-definition/grid-template-columns-rows-resolved-values-001.xht
+++ b/css-grid-1/grid-definition/grid-template-columns-rows-resolved-values-001.xht
@@ -15,6 +15,8 @@
                 width: 800px;
                 height: 600px;
                 font: 10px/1 Ahem;
+                justify-content: start;
+                align-content: start;
             }
 
             .fifthColumn {

--- a/css-grid-1/grid-items/grid-items-001.xht
+++ b/css-grid-1/grid-items/grid-items-001.xht
@@ -21,6 +21,8 @@
                 font: 25px/1 Ahem;
                 color: green;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-items/grid-items-002.xht
+++ b/css-grid-1/grid-items/grid-items-002.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 25px/1 Ahem;
                 color: green;
+                justify-content: start;
+                align-content: start;
             }
 
             .two-columns {

--- a/css-grid-1/grid-items/grid-order-property-auto-placement-001.xht
+++ b/css-grid-1/grid-items/grid-order-property-auto-placement-001.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 50px/1 Ahem;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
 
             #blue {

--- a/css-grid-1/grid-items/grid-order-property-auto-placement-002.xht
+++ b/css-grid-1/grid-items/grid-order-property-auto-placement-002.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 50px/1 Ahem;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
 
             #blue {

--- a/css-grid-1/grid-items/grid-order-property-auto-placement-003.xht
+++ b/css-grid-1/grid-items/grid-order-property-auto-placement-003.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 50px/1 Ahem;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
 
             #blue {

--- a/css-grid-1/grid-items/grid-order-property-auto-placement-004.xht
+++ b/css-grid-1/grid-items/grid-order-property-auto-placement-004.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 50px/1 Ahem;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
 
             #blue {

--- a/css-grid-1/grid-items/grid-order-property-auto-placement-005.xht
+++ b/css-grid-1/grid-items/grid-order-property-auto-placement-005.xht
@@ -20,6 +20,8 @@
                 display: grid;
                 font: 50px/1 Ahem;
                 grid-template-columns: auto auto;
+                justify-content: start;
+                align-content: start;
             }
 
             #blue {

--- a/css-grid-1/grid-layout-properties.html
+++ b/css-grid-1/grid-layout-properties.html
@@ -18,6 +18,8 @@
     }
     #myDiv {
         font: 50px/1 Ahem;
+        justify-content: start;
+        align-content: start;
     }
   </style>
 </head>
@@ -108,7 +110,7 @@
       'grid-template': {
         initial: '150px / 50px 50px 50px',
         'none': ['', '150px / 50px 50px 50px'],
-        '<grid-template-columns> / <grid-template-rows>': ['200px 200px / 100px 100px', '200px 200px / 100px 100px'],
+        '<grid-template-rows> / <grid-template-columns>': ['100px 100px / 200px 200px', '100px 100px / 200px 200px'],
         '<line-names>': ['[a] auto [b] auto [c] / [d] auto [e] auto [f]', '[a] auto [b] auto [c] / [d] auto [e] auto [f]'],
         '<string>+': ['"a b" "a b"', '"a b" "a b"'],
         '<string><track-size>+': ['100px / "a b" 50px', '100px / "a b" 50px'],

--- a/css-grid-1/implicit-grids/grid-support-grid-auto-columns-rows-001.html
+++ b/css-grid-1/implicit-grids/grid-support-grid-auto-columns-rows-001.html
@@ -34,7 +34,7 @@
         <div id="grid">
             <div id="first-column-first-row"></div>
             <div id="third-column-first-and-second-rows"></div>
-            <div id="third-column"></div>
+            <div id="first-and-second-columns-second-row"></div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This is a commit with changes in several tests to update them
to the last changes on the spec.

The changes can be summarized in:
* Use "justify|align-content: start" to avoid the stretch by default.
* Change order of rows and columns in grid-template shorthand.
* "fr" unit is now invalid as minimum track sizing function.
* Fix mistake on grid-support-grid-auto-columns-rows-001.html:
  It was defining a class "first-and-second-columns-second-row"
  but using a non existent one called "third-column".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1194)
<!-- Reviewable:end -->
