### PR TITLE
[css-grid] Update implied minimum size of grid items tests

### DIFF
--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-001.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-001.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
@@ -18,7 +18,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-002.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-002.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
         <style type="text/css"><![CDATA[
@@ -17,7 +17,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-003.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-003.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size regardless of the content size." />
         <style type="text/css"><![CDATA[
@@ -17,7 +17,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-004.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-004.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size regardless of the content size." />
         <style type="text/css"><![CDATA[
@@ -17,7 +17,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-005.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-005.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
@@ -18,7 +18,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-006.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-006.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for width (regardless the content size) and the transferred size for height (as it's smaller than the content size of the image)." />
@@ -18,7 +18,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-007.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-007.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for width (regardless the content size) and the content size for height (as it's smaller than the transferred size of the image)." />
@@ -18,11 +18,14 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {
                 width: 100px;
+                justify-self: stretch;
+                align-self: stretch;
             }
         ]]></style>
     </head>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-008.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-008.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for height (regardless the content size) and the transferred size for width (as it's smaller than the content size of the image)." />
@@ -18,7 +18,8 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-009.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-009.xht
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
-        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items" />
+        <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
         <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for height (regardless the content size) and the content size for width (as it's smaller than the transferred size of the image)." />
@@ -18,11 +18,14 @@
 
             #constrained-grid {
                 display: grid;
-                grid: 10px / 10px;
+                width: 10px;
+                height: 10px;
             }
 
             #test-grid-item-overlapping-green {
                 height: 100px;
+                justify-self: stretch;
+                align-self: stretch;
             }
         ]]></style>
     </head>


### PR DESCRIPTION
Once that issue w3c/csswg-drafts#283 has been solved, this patch
is updating the current tests related to "Implied Minimum Size
of Grid Items" section:
https://drafts.csswg.org/css-grid/#min-size-auto

Please @javifernandez and @svillar take a look to the changes, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1198)
<!-- Reviewable:end -->
