### PR TITLE
[css-grid] Add more tests for Implied Minimum Size of Grid Items section

### DIFF
--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    grid: 100px / 100px;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid: minmax(0px, 500px) / minmax(0px, 500px);
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid: minmax(0px, auto) / minmax(0px, auto);
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="flags" content="ahem">
+<meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item has not stretch alignment.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    grid: 10px / 10px;
+}
+
+#test-grid-item-overlapping-green {
+    color: green;
+    background-color: green;
+    font: 50px/1 Ahem;
+    justify-self: start;
+    align-self: start;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">IT E</div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="ahem">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item has not stretch alignment.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    grid: 10px / 10px;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+    justify-self: start;
+    align-self: start;
+}
+
+#content-100x100 {
+    width: 100px;
+    height: 100px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-100x100"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item has not stretch alignment.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item if it spans some not fixed grid tracks.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item if it spans some not fixed grid tracks.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    grid: 10px auto 10px / 10px auto 10px;
+    justify-content: start;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+    grid-row: span 3;
+    grid-column: span 3;
+}
+
+#content-100x100 {
+    width: 100px;
+    height: 100px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-100x100"></div>
+    </div>
+</div>
+

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is clamped if the grid item only spans fixed grid tracks.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    grid: 50px 30px 20px / 50px 30px 20px;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+    grid-row: span 3;
+    grid-column: span 3;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is clamped if the grid item only spans fixed grid tracks.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 10px;
+    height: 10px;
+    grid: minmax(auto, 0px) / minmax(auto, 0px);
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-100x100 {
+    width: 100px;
+    height: 100px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-100x100"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 10px;
+    height: 10px;
+    grid: minmax(auto, 500px) / minmax(auto, 500px);
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-100x100 {
+    width: 100px;
+    height: 100px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-100x100"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
 <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">


### PR DESCRIPTION
This adds more coverage for that spec section:
https://drafts.csswg.org/css-grid/#min-size-auto

The examples in the tests were discussed in w3c/csswg-drafts#283.

Please @javifernandez or @svillar take a look. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1199)
<!-- Reviewable:end -->
