### PR TITLE
[css-grid] Use image in the reference for tests that show an image

### DIFF
--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-005.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-005.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="ref-filled-green-100px-square-image.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-006.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-006.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="ref-filled-green-100px-square-image.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for width (regardless the content size) and the transferred size for height (as it's smaller than the content size of the image)." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-007.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-007.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="ref-filled-green-100px-square-image.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for width (regardless the content size) and the content size for height (as it's smaller than the transferred size of the image)." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-008.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-008.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="ref-filled-green-100px-square-image.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for height (regardless the content size) and the transferred size for width (as it's smaller than the content size of the image)." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-009.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-009.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="ref-filled-green-100px-square-image.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size for height (regardless the content size) and the content size for width (as it's smaller than the transferred size of the image)." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/ref-filled-green-100px-square-image.html
+++ b/css-grid-1/grid-items/ref-filled-green-100px-square-image.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference: 100x100 green square image</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<img src="support/100x100-green.png" alt="Image download support must be enabled" />


### PR DESCRIPTION
We have issues comparing a green image with a green box from HTML/CSS,
using images in the reference files solves the problem.

Check comments on #1202 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1204)
<!-- Reviewable:end -->
