### PR TITLE
[css-display-3] Remove outdated display: contents test.

### DIFF
--- a/css-display-3/display-contents-alignment-001-ref.html
+++ b/css-display-3/display-contents-alignment-001-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<style>
+  .container {
+    display: flex;
+    width: 300px;
+    height: 300px;
+    align-items: center;
+    border: 2px solid purple;
+  }
+  .container > div {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    align-self: auto;
+  }
+</style>
+<p>Test passes if there's a blue square vertically centered inside the box.</p>
+<div class="container">
+  <div></div>
+</div>

--- a/css-display-3/display-contents-alignment-001.html
+++ b/css-display-3/display-contents-alignment-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: flex container align-items is used for flex item regardless of intermediate display: contents ancestors</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="help" href="https://drafts.csswg.org/css-align/#align-items-property">
+<link rel="match" href="display-contents-alignment-001-ref.html">
+<style>
+  .container {
+    display: flex;
+    width: 300px;
+    height: 300px;
+    align-items: center;
+    border: 2px solid purple;
+  }
+  .contents {
+    display: contents;
+    align-items: flex-start;
+  }
+  .contents > div {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    align-self: auto;
+  }
+</style>
+<p>Test passes if there's a blue square vertically centered inside the box.</p>
+<div class="container">
+  <div class="contents">
+    <div></div>
+  </div>
+</div>

--- a/css-display-3/display-contents-alignment-002-ref.html
+++ b/css-display-3/display-contents-alignment-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<style>
+  .container {
+    display: grid;
+    width: 300px;
+    height: 300px;
+    justify-items: center;
+    border: 2px solid purple;
+  }
+  .container > div {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    justify-self: auto;
+  }
+</style>
+<p>Test passes if there's a blue square horizontally centered inside the box.</p>
+<div class="container">
+  <div></div>
+</div>

--- a/css-display-3/display-contents-alignment-002.html
+++ b/css-display-3/display-contents-alignment-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: grid container justify-items is used for grid item regardless of intermediate display: contents ancestors</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:ecobos@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="help" href="https://drafts.csswg.org/css-align/#justify-items-property">
+<link rel="match" href="display-contents-alignment-002-ref.html">
+<style>
+  .container {
+    display: grid;
+    width: 300px;
+    height: 300px;
+    justify-items: center;
+    border: 2px solid purple;
+  }
+  .contents {
+    display: contents;
+    justify-items: start;
+  }
+  .contents > div {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    justify-self: auto;
+  }
+</style>
+<p>Test passes if there's a blue square horizontally centered inside the box.</p>
+<div class="container">
+  <div class="contents">
+    <div></div>
+  </div>
+</div>

--- a/css-display-3/display-contents-computed-style.html
+++ b/css-display-3/display-contents-computed-style.html
@@ -15,11 +15,7 @@
 
     #t3 .contents { color: green }
 
-    #t4 { display: flex; align-items: center }
-    #t4 .contents { align-items: baseline }
-    #t4 span { align-self: auto }
-
-    #t5 {
+    #t4 {
         width: auto;
         height: 50%;
         margin-left: 25%;
@@ -42,7 +38,7 @@
         <span></span>
     </div>
 </div>
-<div id="t5" class="contents"></div>
+<div id="t4" class="contents"></div>
 <script>
     test(function(){
         assert_equals(getComputedStyle(document.querySelector("#t1")).display, "contents");
@@ -57,11 +53,7 @@
     }, "display:contents element as inherit parent - implicit inheritance");
 
     test(function(){
-        assert_equals(getComputedStyle(document.querySelector("#t4 span")).alignSelf, "baseline");
-    }, "align-self:auto resolution for flex item inside display:contents");
-
-    test(function(){
-        var computed = getComputedStyle(document.querySelector("#t5"));
+        var computed = getComputedStyle(document.querySelector("#t4"));
         assert_equals(computed.width, "auto");
         assert_equals(computed.height, "50%");
         assert_equals(computed.marginLeft, "25%");


### PR DESCRIPTION
The flex spec was updated a while ago to use the following language for
align-items:

> align-items sets the default alignment for all of the flex container’s items,
> including anonymous flex items. align-self allows this default alignment to
> be overridden for individual flex items.

After that, the CSSWG resolved that align-self: auto computes to itself (see [1] and [2]).

Thus, this test is invalid.

[1]: https://github.com/w3c/csswg-drafts/issues/440#issuecomment-247595259
[2]: https://lists.w3.org/Archives/Public/www-style/2016Sep/0041.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1209)
<!-- Reviewable:end -->
