### PR TITLE
[css-grid] Fix path to reference file in grid-items/grid-items-sizing-alignment-001.html

### DIFF
--- a/css-grid-1/grid-items/grid-items-sizing-alignment-001.html
+++ b/css-grid-1/grid-items/grid-items-sizing-alignment-001.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Grid Item Sizing</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://www.w3.org/TR/css-grid-1/#grid-item-sizing">
-<link rel="match" href="../reference/grid-items-sizing-alignment-001-ref.html" />
+<link rel="match" href="grid-items-sizing-alignment-001-ref.html" />
 <meta name="assert" content="Checks how alignment properties affect the size of the non-replaced vs replaced grid items.">
 <style>
   #grid {


### PR DESCRIPTION

A mistake in the last pull request #1219.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1224)
<!-- Reviewable:end -->
