### PR TITLE
[css-grid] Remove grid-items/grid-items-sizing-alignment-001.html from lint.whitelist

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -108,7 +108,6 @@ SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/masking/blank
 SUPPORT-WRONG-DIR: vendor-imports/mozilla/mozilla-central-reftests/transforms/green.html
 SUPPORT-WRONG-DIR: WOFF2-UserAgent/manifest.txt
 SUPPORT-WRONG-DIR: WOFF2-UserAgent/Tests/xhtml1/testcaseindex.xht
-NON-EXISTENT-REF: css-grid-1/grid-items/grid-items-sizing-alignment-001.html
 NON-EXISTENT-REF: css-masking-1/clip-path-svg-content/clip-path-clip-rule-008.svg
 NON-EXISTENT-REF: css-masking-1/clip-path-svg-content/clip-path-precision-001.svg
 NON-EXISTENT-REF: css-shapes-1/spec-examples/shape-outside-012.html


### PR DESCRIPTION
Again related to my previous PRs #1219 & #1224, sorry for the noise :disappointed:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1226)
<!-- Reviewable:end -->
