### PR TITLE
[css-grid] Avoid references to external tests suites

### DIFF
--- a/css-grid-1/grid-items/grid-inline-items-001.xht
+++ b/css-grid-1/grid-items/grid-inline-items-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Regular and anonymous grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that inline grid container children become grid items, and text that is directly contained inside the inline grid is wrapped in an anonymous grid item." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-inline-items-002.xht
+++ b/css-grid-1/grid-items/grid-inline-items-002.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Children of grid items do not create new items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that the grid items do not split around blocks creating extra items within an inline grid." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-inline-items-003.xht
+++ b/css-grid-1/grid-items/grid-inline-items-003.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Grid items with 'display:none' are not rendered within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-inline-items-inline-blocks-001.xht
+++ b/css-grid-1/grid-items/grid-inline-items-inline-blocks-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="9.5 Z-axis Ordering: the z-index property" />
         <link rel="help" href="http://www.w3.org/TR/CSS2/zindex.html#painting-order" title="E.2 Painting order" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #inline-grid {
                 display: inline-grid;

--- a/css-grid-1/grid-items/grid-inline-order-property-painting-001.xht
+++ b/css-grid-1/grid-items/grid-inline-order-property-painting-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-order-property-painting-002.xht
+++ b/css-grid-1/grid-items/grid-inline-order-property-painting-002.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-order-property-painting-003.xht
+++ b/css-grid-1/grid-items/grid-inline-order-property-painting-003.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-order-property-painting-004.xht
+++ b/css-grid-1/grid-items/grid-inline-order-property-painting-004.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-order-property-painting-005.xht
+++ b/css-grid-1/grid-items/grid-inline-order-property-painting-005.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-z-axis-ordering-001.xht
+++ b/css-grid-1/grid-items/grid-inline-z-axis-ordering-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-z-axis-ordering-002.xht
+++ b/css-grid-1/grid-items/grid-inline-z-axis-ordering-002.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-z-axis-ordering-003.xht
+++ b/css-grid-1/grid-items/grid-inline-z-axis-ordering-003.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-z-axis-ordering-004.xht
+++ b/css-grid-1/grid-items/grid-inline-z-axis-ordering-004.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-inline-z-axis-ordering-005.xht
+++ b/css-grid-1/grid-items/grid-inline-z-axis-ordering-005.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items within an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #inline-grid {

--- a/css-grid-1/grid-items/grid-item-containing-block-001.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-001.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
 <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <style>
     #grid {
         display: grid;

--- a/css-grid-1/grid-items/grid-item-containing-block-002.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
 <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <style>
     #grid {
         display: grid;

--- a/css-grid-1/grid-items/grid-item-containing-block-003.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-003.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
 <meta name="assert" content="A grid item is sized within the containing block defined by its grid area">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <style>
     #grid {
         display: grid;

--- a/css-grid-1/grid-items/grid-item-containing-block-004.html
+++ b/css-grid-1/grid-items/grid-item-containing-block-004.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Tomek Wytrebowicz" href="mailto:tomalecpub@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4. Grid Items">
 <meta name="assert" content="A grid item is sized within the containing block defined by its grid area that intersects flexible tracks">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <style>
     #grid {
         display: grid;

--- a/css-grid-1/grid-items/grid-items-001.xht
+++ b/css-grid-1/grid-items/grid-items-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Regular and anonymous grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that grid container children become grid items, and text that is directly contained inside the grid is wrapped in an anonymous grid item." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-items-002.xht
+++ b/css-grid-1/grid-items/grid-items-002.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Children of grid items do not create new items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that the grid items do not split around blocks creating extra items." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-items-003.xht
+++ b/css-grid-1/grid-items/grid-items-003.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Grid items with 'display:none' are not rendered</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-items" title="4 Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-items-inline-blocks-001.xht
+++ b/css-grid-1/grid-items/grid-items-inline-blocks-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="9.5 Z-axis Ordering: the z-index property" />
         <link rel="help" href="http://www.w3.org/TR/CSS2/zindex.html#painting-order" title="E.2 Painting order" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #grid {
                 display: grid;

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-001.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-002.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-002.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the content size." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-003.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-003.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size regardless of the content size." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-004.xht
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-004.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: Minimum size of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.6. Implied Minimum Size of Grid Items" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="Checks that minimum size for grid items is the specified size regardless of the content size." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-010.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-011.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-012.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-013.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="ahem">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item has not stretch alignment.">
 <style>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-014.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item has not stretch alignment.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-015.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the grid item if it spans some not fixed grid tracks.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-016.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is clamped if the grid item only spans fixed grid tracks.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-017.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-018.html
@@ -3,7 +3,7 @@
 <title>CSS Grid Layout Test: Minimum size of grid items</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
-<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Checks that automatic minimum size is not clamped if the track has an 'auto' min track sizing function.">
 <style>
 #reference-overlapped-red {

--- a/css-grid-1/grid-items/grid-order-property-painting-001.xht
+++ b/css-grid-1/grid-items/grid-order-property-painting-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-order-property-painting-002.xht
+++ b/css-grid-1/grid-items/grid-order-property-painting-002.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-order-property-painting-003.xht
+++ b/css-grid-1/grid-items/grid-order-property-painting-003.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-order-property-painting-004.xht
+++ b/css-grid-1/grid-items/grid-order-property-painting-004.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-order-property-painting-005.xht
+++ b/css-grid-1/grid-items/grid-order-property-painting-005.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#order-property" title="4.2 Reordered Grid Items: the order property" />
         <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#order-property" title="5.4. Display Order: the order property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-z-axis-ordering-001.xht
+++ b/css-grid-1/grid-items/grid-z-axis-ordering-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-z-axis-ordering-002.xht
+++ b/css-grid-1/grid-items/grid-z-axis-ordering-002.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-z-axis-ordering-003.xht
+++ b/css-grid-1/grid-items/grid-z-axis-ordering-003.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-z-axis-ordering-004.xht
+++ b/css-grid-1/grid-items/grid-z-axis-ordering-004.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-items/grid-z-axis-ordering-005.xht
+++ b/css-grid-1/grid-items/grid-z-axis-ordering-005.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: 'z-index' property controls the z-axis order of grid items</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#z-order" title="4.4. Z-axis Ordering: the z-index property" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #grid {

--- a/css-grid-1/grid-model/grid-display-grid-001.xht
+++ b/css-grid-1/grid-model/grid-display-grid-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2014-11-18 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="This test checks that 'grid' value for 'display' property generates a block level containing box." />
         <style type="text/css"><![CDATA[

--- a/css-grid-1/grid-model/grid-display-inline-grid-001.xht
+++ b/css-grid-1/grid-model/grid-display-inline-grid-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2014-11-18 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="This test checks that 'inline-grid' value for 'display' property generates an inline level containing box." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-model/grid-float-001.xht
+++ b/css-grid-1/grid-model/grid-float-001.xht
@@ -6,7 +6,7 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-01-03 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#float-position" title="9.5.1 Positioning the float" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {
                 position: absolute;

--- a/css-grid-1/grid-model/grid-floats-no-intrude-001.xht
+++ b/css-grid-1/grid-model/grid-floats-no-intrude-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: floats do not intrude into a grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {
                 position: absolute;

--- a/css-grid-1/grid-model/grid-inline-float-001.xht
+++ b/css-grid-1/grid-model/grid-inline-float-001.xht
@@ -6,7 +6,7 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-01-03 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#float-position" title="9.5.1 Positioning the float" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {
                 position: absolute;

--- a/css-grid-1/grid-model/grid-inline-floats-no-intrude-001.xht
+++ b/css-grid-1/grid-model/grid-inline-floats-no-intrude-001.xht
@@ -4,7 +4,7 @@
         <title>CSS Grid Layout Test: floats do not intrude into an inline grid</title>
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {
                 position: absolute;

--- a/css-grid-1/grid-model/grid-inline-multicol-001.xht
+++ b/css-grid-1/grid-model/grid-inline-multicol-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/css3-multicol/#the-number-and-width-of-columns" title="3. The number and width of columns" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="This test checks that 'column-*' properties in the Multicol module are ignored in grid items when applied to an inline grid container." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-model/grid-inline-vertical-align-001.xht
+++ b/css-grid-1/grid-model/grid-inline-vertical-align-001.xht
@@ -6,7 +6,7 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2014-12-10 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align" title="10.8.1 Leading and half-leading" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-model/grid-multicol-001.xht
+++ b/css-grid-1/grid-model/grid-multicol-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com" />
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/css3-multicol/#the-number-and-width-of-columns" title="3. The number and width of columns" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="assert" content="This test checks that 'column-*' properties in the Multicol module are ignored in grid items when applied to a grid container." />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/grid-model/grid-vertical-align-001.xht
+++ b/css-grid-1/grid-model/grid-vertical-align-001.xht
@@ -6,7 +6,7 @@
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2014-12-10 -->
         <link rel="help" href="http://www.w3.org/TR/css-grid-1/#grid-containers" title="3.1 Establishing Grid Containers" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align" title="10.8.1 Leading and half-leading" />
-        <link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="ahem" />
         <style type="text/css"><![CDATA[
             #reference-overlapped-red {

--- a/css-grid-1/reference/ref-filled-green-100px-square.xht
+++ b/css-grid-1/reference/ref-filled-green-100px-square.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>


### PR DESCRIPTION
We were using as reference: `css21/reference/ref-filled-green-100px-square.xht`
Copying that file into `css-grid-1/reference/` and use that path,
so the test suite is self-contained.

This was causing issues to import the test suite into WebKit.
Please @gsnedders could you confirm if this change is fine? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1229)
<!-- Reviewable:end -->
