### PR TITLE
[css-align] Added tests to verify the parsing of the place-self shorthand.

### DIFF
--- a/css-align-3/resources/alignment-parsing-utils.js
+++ b/css-align-3/resources/alignment-parsing-utils.js
@@ -13,6 +13,11 @@ function checkPlaceItems(alignValue, justifyValue = "")
     checkPlaceShorhand("place-items", "align-items", "justify-items", alignValue, justifyValue);
 }
 
+function checkPlaceSelf(alignValue, justifyValue = "")
+{
+    checkPlaceShorhand("place-self", "align-self", "justify-self", alignValue, justifyValue);
+}
+
 function checkPlaceShorhand(shorthand, alignLonghand, justifyLonghand, alignValue, justifyValue = "")
 {
     var div = document.createElement("div");
@@ -27,4 +32,22 @@ function checkPlaceShorhand(shorthand, alignLonghand, justifyLonghand, alignValu
                   alignValue, alignLonghand + " resolved value");
     assert_equals(style.getPropertyValue(justifyLonghand),
                   justifyValue, justifyLonghand + " resolved value");
+}
+
+function checkPlaceSelfInvalidValues(value)
+{
+    checkPlaceShorhandInvalidValues("place-self", "align-self", "justify-self", value);
+}
+
+function checkPlaceShorhandInvalidValues(shorthand, alignLonghand, justifyLonghand, value)
+{
+    var div = document.createElement("div");
+    var css = alignLonghand + ": start; " + justifyLonghand + ": end;" + shorthand + ": " + value;
+    div.setAttribute("style", css);
+    document.body.appendChild(div);
+    var style = getComputedStyle(div);
+    assert_equals(style.getPropertyValue(alignLonghand),
+                  "start", alignLonghand + " resolved value");
+    assert_equals(style.getPropertyValue(justifyLonghand),
+                  "end", justifyLonghand + " resolved value");
 }

--- a/css-align-3/self-alignment/place-self-shorthand-001.html
+++ b/css-align-3/self-alignment/place-self-shorthand-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - single values specified</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that setting a single value to place-self expands to such value set in both 'align-self' and  'justify-self'." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<div id="log"></div>
+<script>
+    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    values.forEach(function(value) {
+        test(function() { checkPlaceSelf(value, "") }, "Checking place-self: " + value);
+    });
+</script>

--- a/css-align-3/self-alignment/place-self-shorthand-002.html
+++ b/css-align-3/self-alignment/place-self-shorthand-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - multiple values specified</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that setting two values to place-self sets the first one to 'align-self' and the second one to 'justify-self'." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
+<div id="log"></div>
+<script>
+    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    values.forEach(function(alignValue) {
+        values.forEach(function(justifyValue) {
+            test(function() { checkPlaceSelf(alignValue, justifyValue) },
+                 "place-self: " + alignValue + " " + justifyValue);
+        });
+    });
+</script>

--- a/css-align-3/self-alignment/place-self-shorthand-003.html
+++ b/css-align-3/self-alignment/place-self-shorthand-003.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - initial value</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that place-self's 'initial' value expands to 'align-self' and 'justify-self'." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    #test {
+        align-self: start;
+        justify-self: end;
+    }
+</style>
+<div id="log"></div>
+<div id="test"></div>
+<script>
+    var div = document.getElementById("test");
+    div.setAttribute("style", "place-self: initial");
+    var style = getComputedStyle(div);
+
+    test(function() {
+        assert_equals(style.getPropertyValue("place-self"),
+            "normal normal", "place-self resolved value");
+    }, "Check place-self: initial - resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("align-self"),
+            "normal", "place-self specified value for align-self");
+    }, "Check place-self: initial - align-self resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("justify-self"),
+            "normal", "place-self specified value for justify-self");
+    }, "Check place-self: initial - justify-self resolved value");
+</script>

--- a/css-align-3/self-alignment/place-self-shorthand-004.html
+++ b/css-align-3/self-alignment/place-self-shorthand-004.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - invalid values</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that place-self's invalid values are properly detected at parsing time." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
+<div id="log"></div>
+<div id="test"></div>
+<script>
+    test(function() {
+        checkPlaceSelfInvalidValues("center safe")
+        checkPlaceSelfInvalidValues("true center")
+    }, "Verify overflow keywords are invalid");
+
+    test(function() {
+        checkPlaceSelfInvalidValues("center space-between start")
+    }, "Verify fallback values are invalid");
+
+    test(function() {
+        checkPlaceSelfInvalidValues("10px left")
+        checkPlaceSelfInvalidValues("right 10%")
+    }, "Verify numeric values are invalid");
+
+    test(function() {
+        checkPlaceSelfInvalidValues("")
+    }, "Verify empty declaration is invalid");
+</script>

--- a/css-align-3/self-alignment/place-self-shorthand-005.html
+++ b/css-align-3/self-alignment/place-self-shorthand-005.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - inherit value</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that place-self's 'inherit' value expands to 'align-self' and 'justify-self'." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    #test {
+        place-self: start end;
+    }
+</style>
+<div id="log"></div>
+<div id="test"></div>
+<script>
+    var child = document.createElement("div");
+    document.getElementById("test").appendChild(child);
+    child.setAttribute("style", "place-self: inherit");
+    var style = getComputedStyle(child);
+
+    test(function() {
+        assert_equals(style.getPropertyValue("place-self"),
+            "start end", "place-self computed value");
+    }, "Check place-self: inherit - resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("align-self"),
+            "start", "place-self specified value for align-self");
+    }, "Check place-self: inherit - align-self resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("justify-self"),
+           "end", "place-self specified value for justify-self");
+    }, "Check place-self: inherit - justify-self resolved value");
+</script>

--- a/css-align-3/self-alignment/place-self-shorthand-006.html
+++ b/css-align-3/self-alignment/place-self-shorthand-006.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: place-self shorthand - 'auto' value</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
+<meta name="assert" content="Check that place-self accepts 'auto' as second value and expands to 'align-self' and 'justify-self' as 'normal'." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    #test {
+        align-self: center;
+        justify-self: start;
+        place-self: auto auto;
+    }
+</style>
+<div id="log"></div>
+<div id="test"></div>
+<script>
+    var div = document.getElementById("test");
+    var style = getComputedStyle(div);
+
+    test(function() {
+        assert_equals(style.getPropertyValue("place-self"),
+            "normal normal", "place-self computed value");
+    }, "Check place-self: auto - resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("align-self"),
+            "normal", "place-self specified value for align-self");
+    }, "Check place-self: auto - align-self resolved value");
+
+    test(function() {
+        assert_equals(style.getPropertyValue("justify-self"),
+           "normal", "place-self specified value for justify-self");
+    }, "Check place-self: auto - justify-self resolved value");
+</script>


### PR DESCRIPTION
Added several tests to verify that the 'place-self' shorthand is parsed correctly and it sets the corresponding longhand's values.

Please @mrego and @svillar could you take a look ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1232)
<!-- Reviewable:end -->
