### PR TITLE
[css-align] Refactoring of the place-xxx shorthand related tests

### DIFF
--- a/css-align-3/content-distribution/place-content-shorthand-001.html
+++ b/css-align-3/content-distribution/place-content-shorthand-001.html
@@ -2,14 +2,16 @@
 <title>CSS Box Alignment: place-content shorthand - single values specified</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#propdef-place-content" />
-<meta name="assert" content="Check that setting a single value to place-content expands to such value set in both 'align-content' and  'justify-content'." />
+<meta name="assert" content="Check that setting a single value to place-content expands to such value set in both 'align-content' and 'justify-content'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal"].concat(contentPositionValues, distributionValues, baselineValues);
-        values.forEach(function(value) {
-        test(function() { checkPlaceContent(value, "") }, "Checking place-content: " + value);
+    values.forEach(function(value) {
+        test(function() {
+            checkPlaceShorhandLonghands("place-content", "align-content", "justify-content", value);
+        }, "Checking place-content: " + value);
     });
 </script>

--- a/css-align-3/content-distribution/place-content-shorthand-003.html
+++ b/css-align-3/content-distribution/place-content-shorthand-003.html
@@ -5,31 +5,21 @@
 <meta name="assert" content="Check that place-content's 'initial' value expands to 'align-content' and 'justify-content'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-content: start;
-        justify-content: end;
-    }
-</style>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    var div = document.getElementById("test");
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    div.style["align-content"] = "start";
+    div.style["justify-content"] = "end";
     div.setAttribute("style", "place-content: initial");
-    var style = getComputedStyle(div);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-content"),
-            "normal normal", "place-content resolved value");
-    }, "Check place-content: initial - resolved value");
+        assert_equals(div.style["align-content"],
+            "initial", "place-content specified value for align-content");
+    }, "Check place-content: initial - align-content expanded value");
 
     test(function() {
-        assert_equals(style.getPropertyValue("align-content"),
-            "normal", "place-content specified value for align-content");
-    }, "Check place-content: initial - align-content resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("justify-content"),
-            "normal", "place-content specified value for justify-content");
-    }, "Check place-content: initial - justify-content resolved value");
+        assert_equals(div.style["justify-content"],
+            "initial", "place-content specified value for justify-content");
+    }, "Check place-content: initial - justify-content expanded value");
 </script>

--- a/css-align-3/content-distribution/place-content-shorthand-004.html
+++ b/css-align-3/content-distribution/place-content-shorthand-004.html
@@ -2,27 +2,15 @@
 <title>CSS Box Alignment: place-content shorthand - invalid values</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#propdef-place-content" />
-<meta name="flags" content="invalid" />
 <meta name="assert" content="Check that place-content's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-content: start;
-        justify-content: end;
-    }
-</style>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    function checkInvalidValues(value) {
-        var div = document.getElementById("test");
-        div.setAttribute("style", "place-content: " + value);
-        var style = getComputedStyle(div);
-        assert_equals(style.getPropertyValue("align-content"),
-            "start", "align-content computed value");
-        assert_equals(style.getPropertyValue("justify-content"),
-            "end", "justify-content computed value");
+    function checkInvalidValues(value)
+    {
+       checkPlaceShorthandInvalidValues("place-content", "align-content", "justify-content", value);
     }
 
     test(function() {
@@ -40,8 +28,10 @@
     }, "Verify numeric values are invalid");
 
     test(function() {
-       checkInvalidValues("auto right")
-       checkInvalidValues("auto auto")
+        checkInvalidValues("auto")
+        checkInvalidValues("auto right")
+        checkInvalidValues("auto auto")
+        checkInvalidValues("left auto")
     }, "Verify 'auto' values are invalid");
 
     test(function() {

--- a/css-align-3/content-distribution/place-content-shorthand-005.html
+++ b/css-align-3/content-distribution/place-content-shorthand-005.html
@@ -19,17 +19,12 @@
     var style = getComputedStyle(child);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-content"),
-            "start end", "place-content computed value");
-    }, "Check place-content: inherit - resolved value");
-
-    test(function() {
         assert_equals(style.getPropertyValue("align-content"),
-            "start", "place-content specified value for align-content");
+            "start", "place-content resolved value for align-content");
     }, "Check place-content: inherit - align-content resolved value");
 
     test(function() {
         assert_equals(style.getPropertyValue("justify-content"),
-           "end", "place-content specified value for justify-content");
+           "end", "place-content resolved value for justify-content");
     }, "Check place-content: inherit - justify-content resolved value");
 </script>

--- a/css-align-3/content-distribution/place-content-shorthand-006.html
+++ b/css-align-3/content-distribution/place-content-shorthand-006.html
@@ -1,19 +1,21 @@
 <!DOCTYPE html>
-<title>CSS Box Alignment: place-content shorthand - multiple values specified</title>
+<title>CSS Box Alignment: place-content shorthand - Shorthand 'specified' and 'resolved' value</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#propdef-place-content" />
-<meta name="assert" content="Check that setting two values to place-content sets the first one to 'align-content' and the second one to 'justify-content'." />
+<meta name="assert" content="Check the place-content's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
+<div id="test"></div>
 <script>
     var values = ["normal"].concat(contentPositionValues, distributionValues, baselineValues);
     values.forEach(function(alignValue) {
-        values.forEach(function(justifyValue) {
-           test(function() {
-               checkPlaceShorhandLonghands("place-content", "align-content", "justify-content", alignValue, justifyValue);
-           }, "Checking place-content: " + alignValue + " " + justifyValue);
+        [""].concat(values).forEach(function(justifyValue) {
+            var value = (alignValue + " " + justifyValue).trim();
+            test(function() {
+                checkPlaceShorhand("place-content", alignValue, justifyValue)
+            }, "Checking place-content: " + value);
         });
     });
 </script>

--- a/css-align-3/default-alignment/place-items-shorthand-001.html
+++ b/css-align-3/default-alignment/place-items-shorthand-001.html
@@ -2,14 +2,16 @@
 <title>CSS Box Alignment: place-items shorthand - single values specified</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#place-items-property" />
-<meta name="assert" content="Check that setting a single value to place-items expands to such value set in both 'align-items' and  'justify-items'." />
+<meta name="assert" content="Check that setting a single value to place-items expands to such value set in both 'align-items' and 'justify-items'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
-    var values = ["normal"].concat(selfPositionValues, baselineValues);
-        values.forEach(function(value) {
-        test(function() { checkPlaceItems(value, "") }, "Checking place-items: " + value);
+    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    values.forEach(function(value) {
+        test(function() {
+            checkPlaceShorhandLonghands("place-items", "align-items", "justify-items", value);
+        }, "Checking place-items: " + value);
     });
 </script>

--- a/css-align-3/default-alignment/place-items-shorthand-002.html
+++ b/css-align-3/default-alignment/place-items-shorthand-002.html
@@ -5,14 +5,15 @@
 <meta name="assert" content="Check that setting two values to place-items sets the first one to 'align-items' and the second one to 'justify-items'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../resources/alignment-parsing-utils.js"></script>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
-    var values = ["normal"].concat(selfPositionValues, baselineValues);
+    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
     values.forEach(function(alignValue) {
-        values.forEach(function(justifyValue) {
-            test(function() { checkPlaceItems(alignValue, justifyValue) },
-                 "place-items: " + alignValue + " " + justifyValue);
+       ["auto"].concat(values).forEach(function(justifyValue) {
+           test(function() {
+               checkPlaceShorhandLonghands("place-items", "align-items", "justify-items", alignValue, justifyValue);
+           }, "Checking place-items: " + alignValue + " " + justifyValue);
         });
     });
 </script>

--- a/css-align-3/default-alignment/place-items-shorthand-003.html
+++ b/css-align-3/default-alignment/place-items-shorthand-003.html
@@ -5,31 +5,21 @@
 <meta name="assert" content="Check that place-items's 'initial' value expands to 'align-items' and 'justify-items'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-items: start;
-        justify-items: end;
-    }
-</style>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    var div = document.getElementById("test");
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    div.style["align-items"] = "start";
+    div.style["justify-items"] = "end";
     div.setAttribute("style", "place-items: initial");
-    var style = getComputedStyle(div);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-items"),
-            "normal normal", "place-items resolved value");
-    }, "Check place-items: initial - resolved value");
+        assert_equals(div.style["align-items"],
+            "initial", "place-items expanded value for align-items");
+    }, "Check place-items: initial - align-items expanded value");
 
     test(function() {
-        assert_equals(style.getPropertyValue("align-items"),
-            "normal", "place-items specified value for align-items");
-    }, "Check place-items: initial - align-items resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("justify-items"),
-            "normal", "place-items specified value for justify-items");
-    }, "Check place-items: initial - justify-items resolved value");
+        assert_equals(div.style["justify-items"],
+            "initial", "place-items expanded value for justify-items");
+    }, "Check place-items: initial - justify-items expanded value");
 </script>

--- a/css-align-3/default-alignment/place-items-shorthand-004.html
+++ b/css-align-3/default-alignment/place-items-shorthand-004.html
@@ -5,23 +5,12 @@
 <meta name="assert" content="Check that place-items's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-items: start;
-        justify-items: end;
-    }
-</style>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    function checkInvalidValues(value) {
-        var div = document.getElementById("test");
-        div.setAttribute("style", "place-items: " + value);
-        var style = getComputedStyle(div);
-        assert_equals(style.getPropertyValue("align-items"),
-            "start", "align-items computed value");
-        assert_equals(style.getPropertyValue("justify-items"),
-            "end", "justify-items computed value");
+    function checkInvalidValues(value)
+    {
+       checkPlaceShorthandInvalidValues("place-items", "align-items", "justify-items", value);
     }
 
     test(function() {
@@ -42,7 +31,7 @@
        checkInvalidValues("auto")
        checkInvalidValues("auto right")
        checkInvalidValues("auto auto")
-    }, "Verify 'auto' values are invalid");
+    }, "Verify 'auto' value is invalid as first longhand value.");
 
     test(function() {
         checkInvalidValues("")

--- a/css-align-3/default-alignment/place-items-shorthand-005.html
+++ b/css-align-3/default-alignment/place-items-shorthand-005.html
@@ -19,17 +19,12 @@
     var style = getComputedStyle(child);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-items"),
-            "start end", "place-items computed value");
-    }, "Check place-items: inherit - resolved value");
-
-    test(function() {
         assert_equals(style.getPropertyValue("align-items"),
-            "start", "place-items specified value for align-items");
+            "start", "place-items resolved value for align-items");
     }, "Check place-items: inherit - align-items resolved value");
 
     test(function() {
         assert_equals(style.getPropertyValue("justify-items"),
-           "end", "place-items specified value for justify-items");
+           "end", "place-items resolved value for justify-items");
     }, "Check place-items: inherit - justify-items resolved value");
 </script>

--- a/css-align-3/default-alignment/place-items-shorthand-006.html
+++ b/css-align-3/default-alignment/place-items-shorthand-006.html
@@ -1,33 +1,20 @@
 <!DOCTYPE html>
-<title>CSS Box Alignment: place-items shorthand - 'auto' value</title>
+<title>CSS Box Alignment: place-items shorthand - Shorthand 'specified' and 'resolved' value</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#place-items-property" />
-<meta name="assert" content="Check that place-items accepts 'auto' as second value and expands to 'justify-items' as 'normal'." />
+<meta name="assert" content="Check the place-items's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        place-items: center auto;
-    }
-</style>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    var div = document.getElementById("test");
-    var style = getComputedStyle(div);
-
-    test(function() {
-        assert_equals(style.getPropertyValue("place-items"),
-            "center normal", "place-items computed value");
-    }, "Check place-items: auto - resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("align-items"),
-            "center", "place-items specified value for align-items");
-    }, "Check place-items: auto - align-items resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("justify-items"),
-           "normal", "place-items specified value for justify-items");
-    }, "Check place-items: auto - justify-items resolved value");
+    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    values.forEach(function(alignValue) {
+        ["", "auto"].concat(values).forEach(function(justifyValue) {
+            var value = (alignValue + " " + justifyValue).trim();
+            test(function() {
+                checkPlaceShorhand("place-items", alignValue, justifyValue)
+            }, "Checking place-items: " + value);
+        });
+    });
 </script>

--- a/css-align-3/resources/alignment-parsing-utils.js
+++ b/css-align-3/resources/alignment-parsing-utils.js
@@ -3,51 +3,43 @@ var contentPositionValues = [ "start", "end", "left", "right", "center", "flex-s
 var distributionValues = [ "stretch", "space-around", "space-between", "space-evenly"];
 var baselineValues = [ "baseline", "first baseline", "last baseline"];
 
-function checkPlaceContent(alignValue, justifyValue = "")
+function checkPlaceShorhand(shorthand, alignValue, justifyValue)
 {
-    checkPlaceShorhand("place-content", "align-content", "justify-content", alignValue, justifyValue);
+    var div = document.createElement("div");
+    var value = (alignValue + " " + justifyValue).trim();
+    div.style[shorthand] = value;
+    document.body.appendChild(div);
+    var specifiedValue = alignValue;
+    if (alignValue !== justifyValue)
+        specifiedValue = value;
+    var resolvedValue = getComputedStyle(div).getPropertyValue(shorthand);
+    assert_equals(div.style[shorthand], specifiedValue, shorthand + " specified value");
+    // FIXME: We need https://github.com/w3c/csswg-drafts/issues/1041 to clarify which
+    // value is expected for the shorthand's 'resolved value".
+    assert_true(resolvedValue === value || resolvedValue === "", shorthand + " resolved value");
 }
 
-function checkPlaceItems(alignValue, justifyValue = "")
-{
-    checkPlaceShorhand("place-items", "align-items", "justify-items", alignValue, justifyValue);
-}
-
-function checkPlaceSelf(alignValue, justifyValue = "")
-{
-    checkPlaceShorhand("place-self", "align-self", "justify-self", alignValue, justifyValue);
-}
-
-function checkPlaceShorhand(shorthand, alignLonghand, justifyLonghand, alignValue, justifyValue = "")
+function checkPlaceShorhandLonghands(shorthand, alignLonghand, justifyLonghand, alignValue, justifyValue = "")
 {
     var div = document.createElement("div");
     div.setAttribute("style", shorthand + ": " + alignValue + " " + justifyValue);
     document.body.appendChild(div);
     if (justifyValue === "")
         justifyValue = alignValue;
-    var style = getComputedStyle(div);
-    assert_equals(style.getPropertyValue(shorthand),
-                  alignValue + " " + justifyValue, shorthand + " resolved value");
-    assert_equals(style.getPropertyValue(alignLonghand),
-                  alignValue, alignLonghand + " resolved value");
-    assert_equals(style.getPropertyValue(justifyLonghand),
-                  justifyValue, justifyLonghand + " resolved value");
+    assert_equals(div.style[alignLonghand],
+                  alignValue, alignLonghand + " expanded value");
+    assert_equals(div.style[justifyLonghand],
+                  justifyValue, justifyLonghand + " expanded value");
 }
 
-function checkPlaceSelfInvalidValues(value)
-{
-    checkPlaceShorhandInvalidValues("place-self", "align-self", "justify-self", value);
-}
-
-function checkPlaceShorhandInvalidValues(shorthand, alignLonghand, justifyLonghand, value)
+function checkPlaceShorthandInvalidValues(shorthand, alignLonghand, justifyLonghand, value)
 {
     var div = document.createElement("div");
     var css = alignLonghand + ": start; " + justifyLonghand + ": end;" + shorthand + ": " + value;
     div.setAttribute("style", css);
     document.body.appendChild(div);
-    var style = getComputedStyle(div);
-    assert_equals(style.getPropertyValue(alignLonghand),
-                  "start", alignLonghand + " resolved value");
-    assert_equals(style.getPropertyValue(justifyLonghand),
-                  "end", justifyLonghand + " resolved value");
+    assert_equals(div.style[alignLonghand],
+                  "start", alignLonghand + " expanded value");
+    assert_equals(div.style[justifyLonghand],
+                  "end", justifyLonghand + " expanded value");
 }

--- a/css-align-3/self-alignment/place-self-shorthand-001.html
+++ b/css-align-3/self-alignment/place-self-shorthand-001.html
@@ -2,14 +2,16 @@
 <title>CSS Box Alignment: place-self shorthand - single values specified</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
-<meta name="assert" content="Check that setting a single value to place-self expands to such value set in both 'align-self' and  'justify-self'." />
+<meta name="assert" content="Check that setting a single value to place-self expands to such value set in both 'align-self' and 'justify-self'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
-    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);
     values.forEach(function(value) {
-        test(function() { checkPlaceSelf(value, "") }, "Checking place-self: " + value);
+        test(function() {
+            checkPlaceShorhandLonghands("place-self", "align-self", "justify-self", value);
+        }, "Checking place-self: " + value);
     });
 </script>

--- a/css-align-3/self-alignment/place-self-shorthand-002.html
+++ b/css-align-3/self-alignment/place-self-shorthand-002.html
@@ -5,14 +5,15 @@
 <meta name="assert" content="Check that setting two values to place-self sets the first one to 'align-self' and the second one to 'justify-self'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../resources/alignment-parsing-utils.js"></script>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
-    var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);
+    var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);
     values.forEach(function(alignValue) {
         values.forEach(function(justifyValue) {
-            test(function() { checkPlaceSelf(alignValue, justifyValue) },
-                 "place-self: " + alignValue + " " + justifyValue);
+            test(function() {
+                checkPlaceShorhandLonghands("place-self", "align-self", "justify-self", alignValue, justifyValue);
+            }, "Checking place-self: " + alignValue + " " + justifyValue);
         });
     });
 </script>

--- a/css-align-3/self-alignment/place-self-shorthand-003.html
+++ b/css-align-3/self-alignment/place-self-shorthand-003.html
@@ -5,31 +5,21 @@
 <meta name="assert" content="Check that place-self's 'initial' value expands to 'align-self' and 'justify-self'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-self: start;
-        justify-self: end;
-    }
-</style>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    var div = document.getElementById("test");
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    div.style["align-self"] = "start";
+    div.style["justify-self"] = "end";
     div.setAttribute("style", "place-self: initial");
-    var style = getComputedStyle(div);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-self"),
-            "normal normal", "place-self resolved value");
-    }, "Check place-self: initial - resolved value");
+        assert_equals(div.style["align-self"],
+            "initial", "place-self specified value for align-self");
+    }, "Check place-self: initial - align-self expanded value");
 
     test(function() {
-        assert_equals(style.getPropertyValue("align-self"),
-            "normal", "place-self specified value for align-self");
-    }, "Check place-self: initial - align-self resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("justify-self"),
-            "normal", "place-self specified value for justify-self");
-    }, "Check place-self: initial - justify-self resolved value");
+        assert_equals(div.style["justify-self"],
+            "initial", "place-self specified value for justify-self");
+    }, "Check place-self: initial - justify-self expanded value");
 </script>

--- a/css-align-3/self-alignment/place-self-shorthand-004.html
+++ b/css-align-3/self-alignment/place-self-shorthand-004.html
@@ -5,25 +5,29 @@
 <meta name="assert" content="Check that place-self's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../resources/alignment-parsing-utils.js"></script>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
-<div id="test"></div>
 <script>
+    function checkInvalidValues(value)
+    {
+        checkPlaceShorthandInvalidValues("place-self", "align-self", "justify-self", value);
+    }
+
     test(function() {
-        checkPlaceSelfInvalidValues("center safe")
-        checkPlaceSelfInvalidValues("true center")
+        checkInvalidValues("center safe")
+        checkInvalidValues("true center")
     }, "Verify overflow keywords are invalid");
 
     test(function() {
-        checkPlaceSelfInvalidValues("center space-between start")
+        checkInvalidValues("center space-between start")
     }, "Verify fallback values are invalid");
 
     test(function() {
-        checkPlaceSelfInvalidValues("10px left")
-        checkPlaceSelfInvalidValues("right 10%")
+        checkInvalidValues("10px left")
+        checkInvalidValues("right 10%")
     }, "Verify numeric values are invalid");
 
     test(function() {
-        checkPlaceSelfInvalidValues("")
+        checkInvalidValues("")
     }, "Verify empty declaration is invalid");
 </script>

--- a/css-align-3/self-alignment/place-self-shorthand-005.html
+++ b/css-align-3/self-alignment/place-self-shorthand-005.html
@@ -19,17 +19,12 @@
     var style = getComputedStyle(child);
 
     test(function() {
-        assert_equals(style.getPropertyValue("place-self"),
-            "start end", "place-self computed value");
-    }, "Check place-self: inherit - resolved value");
-
-    test(function() {
         assert_equals(style.getPropertyValue("align-self"),
-            "start", "place-self specified value for align-self");
+            "start", "place-self resolved value for align-self");
     }, "Check place-self: inherit - align-self resolved value");
 
     test(function() {
         assert_equals(style.getPropertyValue("justify-self"),
-           "end", "place-self specified value for justify-self");
+           "end", "place-self resolved value for justify-self");
     }, "Check place-self: inherit - justify-self resolved value");
 </script>

--- a/css-align-3/self-alignment/place-self-shorthand-006.html
+++ b/css-align-3/self-alignment/place-self-shorthand-006.html
@@ -1,35 +1,20 @@
 <!DOCTYPE html>
-<title>CSS Box Alignment: place-self shorthand - 'auto' value</title>
+<title>CSS Box Alignment: place-self shorthand - Shorthand 'specified' and 'resolved' value</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 <link rel="help" href="http://www.w3.org/TR/css3-align/#place-self-property" />
-<meta name="assert" content="Check that place-self accepts 'auto' as second value and expands to 'align-self' and 'justify-self' as 'normal'." />
+<meta name="assert" content="Check the place-self's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-    #test {
-        align-self: center;
-        justify-self: start;
-        place-self: auto auto;
-    }
-</style>
+<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
-<div id="test"></div>
 <script>
-    var div = document.getElementById("test");
-    var style = getComputedStyle(div);
-
-    test(function() {
-        assert_equals(style.getPropertyValue("place-self"),
-            "normal normal", "place-self computed value");
-    }, "Check place-self: auto - resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("align-self"),
-            "normal", "place-self specified value for align-self");
-    }, "Check place-self: auto - align-self resolved value");
-
-    test(function() {
-        assert_equals(style.getPropertyValue("justify-self"),
-           "normal", "place-self specified value for justify-self");
-    }, "Check place-self: auto - justify-self resolved value");
+    var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);
+    values.forEach(function(alignValue) {
+        [""].concat(values).forEach(function(justifyValue) {
+            var value = (alignValue + " " + justifyValue).trim();
+            test(function() {
+                checkPlaceShorhand("place-self", alignValue, justifyValue)
+            }, "Checking place-self: " + value);
+        });
+    });
 </script>


### PR DESCRIPTION
Performed several refactoring on the place¡-content, place-items and place-self alignment shorthands.

Verifying the longhand properties .style values instead of the resolved ones, since the longhand resolved values will be handled by the specific property tests.

Added an additional test to verify the shorthands specified and resolved values serialization.

Plaase, @mrego take a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1233)
<!-- Reviewable:end -->
