### PR TITLE
[css-align] Using relative paths for the utility JS scripts.

### DIFF
--- a/css-align-3/content-distribution/place-content-shorthand-001.html
+++ b/css-align-3/content-distribution/place-content-shorthand-001.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting a single value to place-content expands to such value set in both 'align-content' and 'justify-content'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal"].concat(contentPositionValues, distributionValues, baselineValues);

--- a/css-align-3/content-distribution/place-content-shorthand-002.html
+++ b/css-align-3/content-distribution/place-content-shorthand-002.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting two values to place-content sets the first one to 'align-content' and the second one to 'justify-content'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal"].concat(contentPositionValues, distributionValues, baselineValues);

--- a/css-align-3/content-distribution/place-content-shorthand-004.html
+++ b/css-align-3/content-distribution/place-content-shorthand-004.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that place-content's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     function checkInvalidValues(value)

--- a/css-align-3/content-distribution/place-content-shorthand-006.html
+++ b/css-align-3/content-distribution/place-content-shorthand-006.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check the place-content's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <div id="test"></div>
 <script>

--- a/css-align-3/default-alignment/place-items-shorthand-001.html
+++ b/css-align-3/default-alignment/place-items-shorthand-001.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting a single value to place-items expands to such value set in both 'align-items' and 'justify-items'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);

--- a/css-align-3/default-alignment/place-items-shorthand-002.html
+++ b/css-align-3/default-alignment/place-items-shorthand-002.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting two values to place-items sets the first one to 'align-items' and the second one to 'justify-items'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);

--- a/css-align-3/default-alignment/place-items-shorthand-004.html
+++ b/css-align-3/default-alignment/place-items-shorthand-004.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that place-items's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     function checkInvalidValues(value)

--- a/css-align-3/default-alignment/place-items-shorthand-006.html
+++ b/css-align-3/default-alignment/place-items-shorthand-006.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check the place-items's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["normal", "stretch"].concat(selfPositionValues, baselineValues);

--- a/css-align-3/self-alignment/place-self-shorthand-001.html
+++ b/css-align-3/self-alignment/place-self-shorthand-001.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting a single value to place-self expands to such value set in both 'align-self' and 'justify-self'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);

--- a/css-align-3/self-alignment/place-self-shorthand-002.html
+++ b/css-align-3/self-alignment/place-self-shorthand-002.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that setting two values to place-self sets the first one to 'align-self' and the second one to 'justify-self'." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);

--- a/css-align-3/self-alignment/place-self-shorthand-004.html
+++ b/css-align-3/self-alignment/place-self-shorthand-004.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check that place-self's invalid values are properly detected at parsing time." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     function checkInvalidValues(value)

--- a/css-align-3/self-alignment/place-self-shorthand-006.html
+++ b/css-align-3/self-alignment/place-self-shorthand-006.html
@@ -5,7 +5,7 @@
 <meta name="assert" content="Check the place-self's 'specified' and 'resolved' values serialization." />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css-align-3/resources/alignment-parsing-utils.js"></script>
+<script src="../resources/alignment-parsing-utils.js"></script>
 <div id="log"></div>
 <script>
     var values = ["auto", "normal", "stretch"].concat(selfPositionValues, baselineValues);


### PR DESCRIPTION
Using relative paths for utility JS scripts ease the process of importing the tests to the testing infrastructure of different web engines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1234)
<!-- Reviewable:end -->
