### PR TITLE
[css-grid] Add percentage cases to implied minimum size tests

### DIFF
--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-019.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-019.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size gets clamped, so the grid item doesn't overflow the fixed size area.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 500px;
+    height: 200px;
+    grid: 50% / 20%;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>

--- a/css-grid-1/grid-items/grid-minimum-size-grid-items-020.html
+++ b/css-grid-1/grid-items/grid-minimum-size-grid-items-020.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Minimum size of grid items</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/css-grid-1/#min-size-auto" title="6.5. Implied Minimum Size of Grid Items">
+<link rel="match" href="../../css21/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Checks that automatic minimum size is clamped if the grid item only spans fixed grid tracks.">
+<style>
+#reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+
+#constrained-grid {
+    display: grid;
+    width: 200px;
+    height: 500px;
+    grid: 10% 30px 20px / 50px 30px 10%;
+}
+
+#test-grid-item-overlapping-green {
+    background-color: green;
+    grid-row: span 3;
+    grid-column: span 3;
+}
+
+#content-200x200 {
+    width: 200px;
+    height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="reference-overlapped-red"></div>
+<div id="constrained-grid">
+    <div id="test-grid-item-overlapping-green">
+        <div id="content-200x200"></div>
+    </div>
+</div>


### PR DESCRIPTION
As suggested by @svillar I'm adding cases for percentage to verify that they're considered fixed sizes.

Please @svillar or @javifernandez take a look, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1238)
<!-- Reviewable:end -->
