### PR TITLE
Fix the case when virtualenv exists in PATH but not as a module

### DIFF
--- a/build-css-testsuites.sh
+++ b/build-css-testsuites.sh
@@ -30,7 +30,7 @@ if [ ! -d $VENV ]; then
         exit 1
     fi
 
-    $PYTHON -m virtualenv $VENV || { echo "Please ensure virtualenv is installed"; exit 2; }
+    virtualenv -p $PYTHON $VENV || { echo "Please ensure virtualenv is installed"; exit 2; }
 fi
 
 # Install dependencies


### PR DESCRIPTION
This commonly happens when you're already inside a virtualenv, but can
also happen when there are multiple Python interpreters installed (e.g.,
2 and 3) and virtualenv is installed in a different one to the one we
decide to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1242)
<!-- Reviewable:end -->
