### PR TITLE
[selectors-4] Fix markup on several :focus-within tests

### DIFF
--- a/selectors-4/focus-within-001-ref.html
+++ b/selectors-4/focus-within-001-ref.html
@@ -11,5 +11,4 @@ div {
 </style>
 <p>Test passes if, when the element below is focused, it is surrounded by a thick green border. There must be no red or blue once it is focused.</p>
 <div>Focus this element</div>
-</body>
 </html>

--- a/selectors-4/focus-within-001.html
+++ b/selectors-4/focus-within-001.html
@@ -35,5 +35,4 @@ border-color: green;
 var focusme = document.getElementById('focusme');
 focusme.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-002.html
+++ b/selectors-4/focus-within-002.html
@@ -37,5 +37,4 @@ There must be no red or blue once it is focused.</p>
 var focusme = document.getElementById('focusme');
 focusme.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-003.html
+++ b/selectors-4/focus-within-003.html
@@ -43,5 +43,4 @@ There must be no red or blue once it is focused.</p>
 var focusme = document.getElementById('focusme');
 focusme.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-004.html
+++ b/selectors-4/focus-within-004.html
@@ -48,5 +48,4 @@ There must be no red or blue once it is focused.</p>
 var editor = document.getElementById('focusme');
 editor.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-005.html
+++ b/selectors-4/focus-within-005.html
@@ -49,5 +49,4 @@ There must be no red or blue once it is focused.</p>
 var editor = document.getElementById('focusme');
 editor.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-006.html
+++ b/selectors-4/focus-within-006.html
@@ -41,7 +41,7 @@ There must be no red or blue once it is focused.</p>
   <div>
     <div>
       <input id="focusme" class="reftest-wait" onfocus="this.classList.toggle('reftest-wait');" value="Focus this element">
-    <div>
+    </div>
   </div>
 </div>
 <script>
@@ -51,5 +51,4 @@ There must be no red or blue once it is focused.</p>
 var editor = document.getElementById('focusme');
 editor.focus();
 </script>
-<body>
 </html>

--- a/selectors-4/focus-within-shadow-001-ref.html
+++ b/selectors-4/focus-within-shadow-001-ref.html
@@ -11,5 +11,4 @@ div {
 </style>
 <p>Test passes if there is a green rectangle below.</p>
 <div></div>
-</body>
 </html>


### PR DESCRIPTION
I guess the goal of these tests was not to use an invalid markup.
This patch just removes some opening `<body>` tags at the end of the HTML files (just before `</html>`). And fixes a missing `<div>` close tag.
Please @frivoal could you take a look? Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1251)
<!-- Reviewable:end -->
